### PR TITLE
Add opa-auth-token to args.

### DIFF
--- a/pkg/opa/opa.go
+++ b/pkg/opa/opa.go
@@ -59,13 +59,14 @@ type Data interface {
 }
 
 // New returns a new Client object.
-func New(url string) Client {
-	return &httpClient{strings.TrimRight(url, "/"), ""}
+func New(url string, auth string) Client {
+	return &httpClient{strings.TrimRight(url, "/"), "", auth}
 }
 
 type httpClient struct {
 	url    string
 	prefix string
+	authentication string
 }
 
 func (c *httpClient) Prefix(path string) Data {
@@ -185,6 +186,11 @@ func (c *httpClient) do(verb, path string, body io.Reader) (*http.Response, erro
 	if err != nil {
 		return nil, err
 	}
+
+	if c.authentication != "" {
+		req.Header.Set("Authorization", "Bearer " + c.authentication)
+	}
+
 	return http.DefaultClient.Do(req)
 }
 

--- a/pkg/opa/opa_test.go
+++ b/pkg/opa/opa_test.go
@@ -65,7 +65,7 @@ func TestHTTPClientMakePatch(t *testing.T) {
 
 	for _, tc := range tests {
 
-		client := &httpClient{"URL", tc.prefix}
+		client := &httpClient{"URL", tc.prefix, ""}
 		var value *interface{}
 
 		if tc.value != "" {


### PR DESCRIPTION
This allows for an authentication token to be used to call opa server.

Usage:
`--opa-auth-token=$(OPA_BEARER_TOKEN)`

Signed-off-by: Kevin Downey <kevdowney@gmail.com>