### PR TITLE
Remove kube-mgmt image from CRD example

### DIFF
--- a/docs/admission-control-crd.md
+++ b/docs/admission-control-crd.md
@@ -91,7 +91,6 @@ subjects:
 
 ```yaml
 name: kube-mgmt
-image: openpolicyagent/kube-mgmt:0.6
 args:
     - "--replicate=opa.example.com/v1/cats"        # replicate custom resources
 ```


### PR DESCRIPTION
This avoids the need to update the image every time we cut a release.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>