### PR TITLE
Fix a typo in manifests/deployment.yml

### DIFF
--- a/manifests/deployment.yml
+++ b/manifests/deployment.yml
@@ -1,4 +1,4 @@
-# Grant OPA/kube-mgmt read-only access to resources. This let's kube-mgmt
+# Grant OPA/kube-mgmt read-only access to resources. This lets kube-mgmt
 # list configmaps to be loaded into OPA as policies.
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This is a trivial change fixing a typo, however considering this file is embedded in https://www.openpolicyagent.org/docs/kubernetes-admission-control.html (see `3. Deploy OPA on top of Kubernetes`) and therefore has a greater level of visibility for people taking this tutorial, I thought it was a typo worth fixing.