### PR TITLE
Fix panic onDelete for DeletedFinalStateUnknown

### DIFF
--- a/pkg/data/generic.go
+++ b/pkg/data/generic.go
@@ -99,6 +99,11 @@ func (s *GenericSync) syncAdd(obj interface{}) {
 }
 
 func (s *GenericSync) syncRemove(obj interface{}) {
+	// OnDelete can return an object of type DeletedFinalStateUnknown if the watch event was missed
+	staleObj, stale := obj.(cache.DeletedFinalStateUnknown)
+	if stale {
+		obj = staleObj.Obj
+	}
 	u := obj.(*unstructured.Unstructured)
 	name := u.GetName()
 	var path = u.GetName()


### PR DESCRIPTION
@tsandall 
This PR fixes a panic when the generic resource watcher receives a Delete event of type DeletedFinalStateUnknown as documented [here](https://github.com/kubernetes/client-go/blob/843f7c4f28b1f647f664f883697107d5c02c5acc/1.5/tools/cache/controller.go#L146-L149)