### PR TITLE
Added support to replicate configmaps in multiple namespaces with "*"

### DIFF
--- a/pkg/policies/configmap.go
+++ b/pkg/policies/configmap.go
@@ -49,7 +49,7 @@ func matchesLabel(cm *v1.ConfigMap) bool {
 
 func matchesNamespace(cm *v1.ConfigMap, policies []string) bool {
 	for _, ns := range policies {
-		if ns == cm.Namespace {
+		if ns == cm.Namespace || ns == "*" {
 			return true
 		}
 	}


### PR DESCRIPTION
@tsandall 
This PR adds the feature that allows kube-mgmt to be configured to search for config maps with the required label in all namespaces without having to specify all the namespaces.