### PR TITLE
allow multiple namespaces to be watched for policies

### DIFF
--- a/cmd/kube-mgmt/main.go
+++ b/cmd/kube-mgmt/main.go
@@ -159,7 +159,7 @@ func run(params *params) {
 				params.enableData,
 			),
 		)
-		_, err = sync.Run()
+		_, err = sync.Run(params.policies)
 		if err != nil {
 			logrus.Fatalf("Failed to start configmap sync: %v", err)
 		}

--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -129,6 +129,11 @@ func (s *Sync) Run(namespaces []string) (chan struct{}, error) {
 	}
 	quit := make(chan struct{})
 
+	if namespaces[0] == "*" {
+		namespaces[0] = v1.NamespaceAll
+		namespaces = namespaces[0:1]
+	}
+
 	for _, namespace := range namespaces {
 		source := cache.NewListWatchFromClient(
 			client,


### PR DESCRIPTION
this fixes an inconsistency with the docs:

> --policies stringSlice
>                            automatically load policies from these namespaces 

but `v1.NamespaceAll` was hardcoded