### PR TITLE
Fix decode error message on configmap synchronizer

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -105,6 +105,7 @@ func New(kubeconfig *rest.Config, opa opa.Client, matcher func(*v1.ConfigMap) (b
 		scheme.AddKnownTypes(
 			*cpy.GroupVersion,
 			&metav1.ListOptions{},
+			&metav1.Status{},
 			&v1.ConfigMapList{},
 			&v1.ConfigMap{})
 		return nil


### PR DESCRIPTION
After running for some time (e.g., 30 minutes to an hour) kube-mgmt
would begin logging the following errors:

E0904 12:18:45.089926 1 streamwatcher.go:109] Unable to decode an event from the watch stream: unable to decode watch event: no kind "Status" is registered for version "v1" in scheme "github.com/open-policy-agent/kube-mgmt/pkg/configmap/configmap.go:102"

This error seems to be referring to the Status field indirectly found
on the ConfigMap type (via the Initializers field.) After running this
version of kube-mgmt overnight, the error no longer occurs and the
configmaps are still be synchronized.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>