### PR TITLE
Add allow /health for readiness probe

### DIFF
--- a/docs/admission-control-secure.md
+++ b/docs/admission-control-secure.md
@@ -145,6 +145,15 @@ kubectl create secret generic inject-policy -n opa --from-file=authz.rego --from
 
 ```
 
+If you have liveness or readiness probes configured on the OPA server for `/health` you will need to add the following `allow` rule to ensure Kubernetes can still access these endpoints. 
+
+```
+# Allow anonymouse access to /health otherwise K8s get 403 and kills pod. 
+allow {
+    input.path = ["health"]
+}
+```
+
 3. Label the `opa-default-system-main` ConfigMap.
 
 ```yaml


### PR DESCRIPTION
When following this guide, [after using the initial ingress tutorial](https://www.openpolicyagent.org/docs/latest/kubernetes-tutorial/) I hit a bug where the pod would crash loop. 

Once I enabled `debug` logging I saw the following messages:

```json 
{
  "client_addr": "10.244.0.1:52444",
  "level": "info",
  "msg": "Sent response.",
  "req_id": 1,
  "req_method": "GET",
  "req_path": "/health",
  "resp_body": "{\n  \"code\": \"unauthorized\",\n  \"message\": \"request rejected by administrative policy\"\n}\n",
  "resp_bytes": 87,
  "resp_duration": 2.773603,
  "resp_status": 401,
  "time": "2020-01-20T12:33:33Z"
}
```

As the tutorial YAML I started from had the readiness and liveness probes configured the auth policy in this guide was causing the pod to be restarted as requests to `/health` failed. 

This PR adds a note to the guide around how to avoid this issue. 
