### PR TITLE
Remove the policy from OPA if ConfigMap's label was removed

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -169,10 +169,16 @@ func (s *Sync) add(obj interface{}) {
 	}
 }
 
-func (s *Sync) update(_, obj interface{}) {
+func (s *Sync) update(oldObj, obj interface{}) {
 	cm := obj.(*v1.ConfigMap)
 	if match, isPolicy := s.matcher(cm); match {
 		s.syncAdd(cm, isPolicy)
+	} else {
+		// check if the label was removed
+		oldCm := oldObj.(*v1.ConfigMap)
+		if match, isPolicy := s.matcher(oldCm); match {
+			s.syncRemove(oldCm, isPolicy)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR checks the previous version of the updated ConfigMap and if it used to match the label `openpolicyagent.org` (policy or data): removes the corresponding policies from OPA.

Here is a small test I did on my local minishift cluster (Kubernetes: v1.11.0+d4cacc0, OpenShift: v3.11.0+0cbc58b):
```
# show that we are using the locally built version
oc get pod opa-5-7v6pd --template='{{range .spec.containers}}{{if eq .name "kube-mgmt"}}{{.image}}{{"\n"}}{{end}}{{end}}'
openpolicyagent/kube-mgmt:0.12-dev2

# create not labelled policy Configmap
oc create configmap mandatory-labels-pod --from-file=./policies/labels/mandatory/pod/mandatory-labels.rego
configmap/mandatory-labels-pod created

# check that it's indeed not loaded
minishift ssh
[docker@minishift ~]$ curl -s -o /dev/null -k -w "%{http_code}" https://172.30.121.201/v1/policies/my-opa/mandatory-labels-pod/mandatory-labels.rego && echo
404

# label the policy ConfigMap
oc label cm mandatory-labels-pod openpolicyagent.org/policy=rego
configmap/mandatory-labels-pod labeled

# check that indeed it's now loaded
minishift ssh
[docker@minishift ~]$ curl -s -o /dev/null -k -w "%{http_code}" https://172.30.121.201/v1/policies/my-opa/mandatory-labels-pod/mandatory-labels.rego && echo
200

# remove the policy label from the ConfigMap
oc label cm mandatory-labels-pod openpolicyagent.org/policy-
configmap/mandatory-labels-pod labeled

# show that indeed the label is removed
oc get cm mandatory-labels-pod --template='{{.spec.labels}}{{"\n"}}'
<no value>

# check that the new code is working: policy is removed from OPA
minishift ssh
[docker@minishift ~]$ curl -s -o /dev/null -k -w "%{http_code}" https://172.30.121.201/v1/policies/my-opa/mandatory-labels-pod/mandatory-labels.rego && echo
404

# put back the label
oc label cm mandatory-labels-pod openpolicyagent.org/policy=rego
configmap/mandatory-labels-pod labeled

# show that the policy is back
minishift ssh
[docker@minishift ~]$ curl -s -o /dev/null -k -w "%{http_code}" https://172.30.121.201/v1/policies/my-opa/mandatory-labels-pod/mandatory-labels.rego && echo
200
```
Regards,
Andrey