### PR TITLE
Fix logic to load policies from all namespaces

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -131,12 +131,10 @@ func (s *Sync) Run(namespaces []string) (chan struct{}, error) {
 	}
 	quit := make(chan struct{})
 
-	if namespaces[0] == "*" {
-		namespaces[0] = v1.NamespaceAll
-		namespaces = namespaces[0:1]
-	}
-
 	for _, namespace := range namespaces {
+		if namespace == "*" {
+			namespace = v1.NamespaceAll
+		}
 		source := cache.NewListWatchFromClient(
 			client,
 			"configmaps",


### PR DESCRIPTION
When kube-mgmt was started with the "--policies=*" option, it would set the array of namespaces with an emtpy string as its only element. This would break the logic of how namespaces are matched thereby not annotating configmaps containing policy and hence policies would not be loaded.

Fixes: #55
Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>