### PR TITLE
README: Add note about using `--policies` for data

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Enable data loading by specifying the `--enable-data` command-line flag to
 `kube-mgmt`. If data loading is enabled `kube-mgmt` will load JSON out of
 ConfigMaps labelled with `openpolicyagent.org/data=opa`.
 
+> The JSON data ConfigMaps must be in namespaces listed in the `--policies` option.
+
 Data loaded out of ConfigMaps is laid out as follows:
 
 ```


### PR DESCRIPTION
The documentation mentions using `--policies` for loading in policy
ConfigMaps and then explains using some other flags and annotations
for loading JSON data. It doesn't explicitly say that the data
ConfigMap needs to also be in the list of namespaces for `--policies`,
which is somewhat confusing just due to the naming (in theory there
may not be _any_ policies involved, just data).

This just adds a note into the README to be a little more explicit.

Signed-off-by: Patrick East <east.patrick@gmail.com>