### PR TITLE
arm support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,10 @@ install:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   - docker buildx create --name xbuilder --use
 after_success:
-- source ./build/travis-utils.sh
-- docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-- make push
-- make push-latest
-# - if is_travis_push_env; then docker login -u $DOCKER_USER -p $DOCKER_PASSWORD; fi
-# - if is_travis_push_env; then make push; fi
-# - if is_travis_release_env; then make push-latest; fi
+  - source ./build/travis-utils.sh
+  - if is_travis_push_env; then docker login -u $DOCKER_USER -p $DOCKER_PASSWORD; fi
+  - if is_travis_push_env; then make push; fi
+  - if is_travis_release_env; then make push-latest; fi
 env:
   global:
   - secure: k/I694fyeCLB3V25PphikqkAZ49Il8PScGc9kkUcuL8E7i3WmUMiVgp+6J4tlUKUmJI07U8eZIolqhMMskKRDfBcQd/UzG0V+MTeY29JXj8aLZyylKsbNksbY6bnC/U7sSRkvYXiwznWo4C9/Fks8KAHVDPBejAAgkqL+vdCJZ6HypmbIZLbJGZsANQ9b4AE1MyLJ6mQKy0JO6W6ovOQLpfKAxhseJXvg9zePGfxjmioN1+lN5u90CQmDXs7ZT7K5/QwEGBhb6AJe8j5yHL1+qNmcWkBxg8x9fkJ6vuciW29mfKRLsY1wioPmKldSUBO+Z7HmHA2YgHPSNuZqfK3vEBFPXWGpjyGrC8Q6Sijb6LMextyZTt4EmRRvfLFoN3K9ZC7VZjk/m3aqGnhq6HTyMOSMpQIIfmH6SxG2x786H3duBHkXfz4ldsTlR1bk2fv9Ur1lNNy1E66ZQIi5XQp+B6Kd+elNw7UnDU5IgrxzgVTmAS9DLWgxHBYy66Wf3CJAfSxZ1sNARDwRMXM0CvtRoy2nlDvo5sgCoMlw0h/zEXP0rrGm/PBzsLoi6UJ4sN3K86Z2L0oR08Jt+TSDzj7nPYPO72rGPRQ1eJN3It5FUjrDTwWBEQk+It8JNJwId+Aa1aBbsSjX+HlxOtK+dkLgnjcICXov7YaC4bZy8ADfVY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - docker buildx create --name xbuilder --use
 after_success:
 - source ./build/travis-utils.sh
+- mkdir -p ./bin/linux_arm/linux_arm
 - if is_travis_push_env; then docker login -u $DOCKER_USER -p $DOCKER_PASSWORD; fi
 - if is_travis_push_env; then make push; fi
 - if is_travis_release_env; then make push-latest; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,19 @@ go:
 services:
 - docker
 before_install:
-  - curl -fsSL https://get.docker.com | sh
-  - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
-  - mkdir -p $HOME/.docker
-  - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
-  - sudo service docker start
+- curl -fsSL https://get.docker.com | sh
+- echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+- mkdir -p $HOME/.docker
+- echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
+- sudo service docker start
 install:
-  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-  - docker buildx create --name xbuilder --use
+- docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+- docker buildx create --name xbuilder --use
 after_success:
-  - source ./build/travis-utils.sh
-  - if is_travis_push_env; then docker login -u $DOCKER_USER -p $DOCKER_PASSWORD; fi
-  - if is_travis_push_env; then make push; fi
-  - if is_travis_release_env; then make push-latest; fi
+- source ./build/travis-utils.sh
+- if is_travis_push_env; then docker login -u $DOCKER_USER -p $DOCKER_PASSWORD; fi
+- if is_travis_push_env; then make push; fi
+- if is_travis_release_env; then make push-latest; fi
 env:
   global:
   - secure: k/I694fyeCLB3V25PphikqkAZ49Il8PScGc9kkUcuL8E7i3WmUMiVgp+6J4tlUKUmJI07U8eZIolqhMMskKRDfBcQd/UzG0V+MTeY29JXj8aLZyylKsbNksbY6bnC/U7sSRkvYXiwznWo4C9/Fks8KAHVDPBejAAgkqL+vdCJZ6HypmbIZLbJGZsANQ9b4AE1MyLJ6mQKy0JO6W6ovOQLpfKAxhseJXvg9zePGfxjmioN1+lN5u90CQmDXs7ZT7K5/QwEGBhb6AJe8j5yHL1+qNmcWkBxg8x9fkJ6vuciW29mfKRLsY1wioPmKldSUBO+Z7HmHA2YgHPSNuZqfK3vEBFPXWGpjyGrC8Q6Sijb6LMextyZTt4EmRRvfLFoN3K9ZC7VZjk/m3aqGnhq6HTyMOSMpQIIfmH6SxG2x786H3duBHkXfz4ldsTlR1bk2fv9Ur1lNNy1E66ZQIi5XQp+B6Kd+elNw7UnDU5IgrxzgVTmAS9DLWgxHBYy66Wf3CJAfSxZ1sNARDwRMXM0CvtRoy2nlDvo5sgCoMlw0h/zEXP0rrGm/PBzsLoi6UJ4sN3K86Z2L0oR08Jt+TSDzj7nPYPO72rGPRQ1eJN3It5FUjrDTwWBEQk+It8JNJwId+Aa1aBbsSjX+HlxOtK+dkLgnjcICXov7YaC4bZy8ADfVY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,12 @@ install:
   - docker buildx create --name xbuilder --use
 after_success:
 - source ./build/travis-utils.sh
-- if is_travis_push_env; then docker login -u $DOCKER_USER -p $DOCKER_PASSWORD; fi
-- if is_travis_push_env; then make push; fi
-- if is_travis_release_env; then make push-latest; fi
+- docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+- make push
+- make push-latest
+# - if is_travis_push_env; then docker login -u $DOCKER_USER -p $DOCKER_PASSWORD; fi
+# - if is_travis_push_env; then make push; fi
+# - if is_travis_release_env; then make push-latest; fi
 env:
   global:
   - secure: k/I694fyeCLB3V25PphikqkAZ49Il8PScGc9kkUcuL8E7i3WmUMiVgp+6J4tlUKUmJI07U8eZIolqhMMskKRDfBcQd/UzG0V+MTeY29JXj8aLZyylKsbNksbY6bnC/U7sSRkvYXiwznWo4C9/Fks8KAHVDPBejAAgkqL+vdCJZ6HypmbIZLbJGZsANQ9b4AE1MyLJ6mQKy0JO6W6ovOQLpfKAxhseJXvg9zePGfxjmioN1+lN5u90CQmDXs7ZT7K5/QwEGBhb6AJe8j5yHL1+qNmcWkBxg8x9fkJ6vuciW29mfKRLsY1wioPmKldSUBO+Z7HmHA2YgHPSNuZqfK3vEBFPXWGpjyGrC8Q6Sijb6LMextyZTt4EmRRvfLFoN3K9ZC7VZjk/m3aqGnhq6HTyMOSMpQIIfmH6SxG2x786H3duBHkXfz4ldsTlR1bk2fv9Ur1lNNy1E66ZQIi5XQp+B6Kd+elNw7UnDU5IgrxzgVTmAS9DLWgxHBYy66Wf3CJAfSxZ1sNARDwRMXM0CvtRoy2nlDvo5sgCoMlw0h/zEXP0rrGm/PBzsLoi6UJ4sN3K86Z2L0oR08Jt+TSDzj7nPYPO72rGPRQ1eJN3It5FUjrDTwWBEQk+It8JNJwId+Aa1aBbsSjX+HlxOtK+dkLgnjcICXov7YaC4bZy8ADfVY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,15 @@ go:
 - 1.8
 services:
 - docker
+before_install:
+  - curl -fsSL https://get.docker.com | sh
+  - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+  - mkdir -p $HOME/.docker
+  - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
+  - sudo service docker start
+install:
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  - docker buildx create --name xbuilder --use
 after_success:
 - source ./build/travis-utils.sh
 - if is_travis_push_env; then docker login -u $DOCKER_USER -p $DOCKER_PASSWORD; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ install:
   - docker buildx create --name xbuilder --use
 after_success:
 - source ./build/travis-utils.sh
-- mkdir -p ./bin/linux_arm/linux_arm
 - if is_travis_push_env; then docker login -u $DOCKER_USER -p $DOCKER_PASSWORD; fi
 - if is_travis_push_env; then make push; fi
 - if is_travis_release_env; then make push-latest; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
 - 1.8
 services:
 - docker
+# To use docker buildx for multi architexture builds, the latest version of
+# docker must be installed and the experimental features enabled.
+# Refer to: https://medium.com/@quentin.mcgaw/cross-architecture-docker-builds-with-travis-ci-arm-s390x-etc-8f754e20aaef
 before_install:
 - curl -fsSL https://get.docker.com | sh
 - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM alpine
 
 MAINTAINER Torin Sandall torinsandall@gmail.com
 
-ADD bin/linux_amd64/kube-mgmt /kube-mgmt
+ARG OS=linux
+ARG ARCH=amd64
+
+ADD bin/${OS}_${ARCH}/kube-mgmt /kube-mgmt
 
 USER 1000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM alpine
 
 MAINTAINER Torin Sandall torinsandall@gmail.com
 
-ARG OS=linux
-ARG ARCH=amd64
+ARG SOURCE=bin/linux_amd64/
 
-ADD bin/${OS}_${ARCH}/kube-mgmt /kube-mgmt
+ADD ${SOURCE}/kube-mgmt /kube-mgmt
 
 USER 1000
 

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ build:
 		-v $$(pwd)/.go:/go \
 		-v $$(pwd):/go/src/$(PKG) \
 		-v $$(pwd)/bin/$(OS)_$(ARCH):/go/bin \
-		-v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static \
+		-v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/$(OS)_$(ARCH)_static \
 		-w /go/src/$(PKG) \
 		$(BUILD_IMAGE) \
-		/bin/sh -c "OS=$(OS) ARCH=$(ARCH) VERSION=$(VERSION) COMMIT=$(COMMIT) PKG=$(PKG) ./build/build.sh"
+		/bin/sh -c "GOOS=$(OS) GOARCH=$(ARCH) VERSION=$(VERSION) COMMIT=$(COMMIT) PKG=$(PKG) ./build/build.sh"
 
 .PHONY: build-linux-amd64
 build-linux-amd64:
@@ -31,6 +31,7 @@ build-linux-amd64:
 .PHONY: build-linux-armv6
 build-linux-armv6:
 	make build OS=linux ARCH=arm
+	sudo chown -R $(id -u):$(id -g) ./bin
 	mv ./bin/linux_arm/linux_arm/* ./bin/linux_arm
 	rm -rf ./bin/linux_arm/linux_arm
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BIN := kube-mgmt
 PKG := github.com/open-policy-agent/kube-mgmt
-REGISTRY ?= pietervicloudcom
+REGISTRY ?= open-policy-agent
 VERSION := 0.12-dev
 ARCH := amd64
 OS := linux

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build-linux-armv6:
 .PHONY: image
 image: build-linux-amd64 build-linux-armv6 
 	docker buildx build -t $(IMAGE):$(VERSION)-linux-amd64 -f Dockerfile --platform linux/amd64 --build-arg SOURCE=bin/linux_amd64/ .
-	docker buildx build -t $(IMAGE):$(VERSION)-linux-armv6 -f Dockerfile --platform linux/arm/v6 --build-arg SOURCE=bin/linux_arm/linux_arm/ .
+	docker buildx build -t $(IMAGE):$(VERSION)-linux-armv6 -f Dockerfile --platform linux/arm/v6 --build-arg SOURCE=bin/linux_arm/ .
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ build-linux-armv6:
 
 .PHONY: image
 image: build-linux-amd64 build-linux-armv6 
-	docker buildx build -t $(IMAGE):$(VERSION)-linux-amd64 -f Dockerfile --platform linux/amd64 --build-arg OS=linux --build-arg ARCH=amd64 .
-	docker buildx build -t $(IMAGE):$(VERSION)-linux-armv6 -f Dockerfile --platform linux/arm/v6 --build-arg OS=linux --build-arg ARCH=arm .
+	docker buildx build -t $(IMAGE):$(VERSION)-linux-amd64 -f Dockerfile --platform linux/amd64 --build-arg SOURCE=bin/linux_amd64/ .
+	docker buildx build -t $(IMAGE):$(VERSION)-linux-armv6 -f Dockerfile --platform linux/arm/v6 --build-arg SOURCE=bin/linux_arm/linux_arm/ .
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build-linux-amd64:
 .PHONY: build-linux-armv6
 build-linux-armv6:
 	make build OS=linux ARCH=arm
-	sudo chown -R $(id -u):$(id -g) ./bin
+	chown -R $(id -u):$(id -g) ./bin
 	mv ./bin/linux_arm/linux_arm/* ./bin/linux_arm
 	rm -rf ./bin/linux_arm/linux_arm
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ build-linux-amd64:
 .PHONY: build-linux-armv6
 build-linux-armv6:
 	make build OS=linux ARCH=arm
-	cp -f ./bin/linux_arm/linux_arm/kube-mgmt ./bin/linux_arm
 
 .PHONY: image
 image: build-linux-amd64 build-linux-armv6 

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,10 @@ build-linux-amd64:
 
 .PHONY: build-linux-armv6
 build-linux-armv6:
+	whoami
+	mkdir -p ./bin/linux_arm/linux_arm
 	make build OS=linux ARCH=arm
-	cp ./bin/linux_arm/linux_arm/* ./bin/linux_arm
+	cp -f ./bin/linux_arm/linux_arm/kube-mgmt ./bin/linux_arm
 
 .PHONY: image
 image: build-linux-amd64 build-linux-armv6 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BIN := kube-mgmt
 PKG := github.com/open-policy-agent/kube-mgmt
-REGISTRY ?= open-policy-agent
+REGISTRY ?= openpolicyagent
 VERSION := 0.12-dev
 ARCH := amd64
 OS := linux

--- a/Makefile
+++ b/Makefile
@@ -31,14 +31,11 @@ build-linux-amd64:
 .PHONY: build-linux-armv6
 build-linux-armv6:
 	make build OS=linux ARCH=arm
-	mkdir -pv $$(pwd)/bin/linux_armv6
-	cp $$(pwd)/bin/linux_arm/linux_arm/* $$(pwd)/bin/linux_armv6
-	rm -rf $$(pwd)/bin/linux_arm
 
 .PHONY: image
 image: build-linux-amd64 build-linux-armv6 
 	docker buildx build -t $(IMAGE):$(VERSION)-linux-amd64 -f Dockerfile --platform linux/amd64 --build-arg OS=linux --build-arg ARCH=amd64 .
-	docker buildx build -t $(IMAGE):$(VERSION)-linux-armv6 -f Dockerfile --platform linux/arm/v6 --build-arg OS=linux --build-arg ARCH=armv6 .
+	docker buildx build -t $(IMAGE):$(VERSION)-linux-armv6 -f Dockerfile --platform linux/arm/v6 --build-arg OS=linux --build-arg ARCH=arm .
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ build-linux-amd64:
 .PHONY: build-linux-armv6
 build-linux-armv6:
 	make build OS=linux ARCH=arm
-	mv $$(pwd)/bin/linux_arm/linux_arm/* $$(pwd)/bin/linux_arm
-	rm -rf $$(pwd)/bin/linux_arm/linux_arm
+	mv ./bin/linux_arm/linux_arm/* ./bin/linux_arm
+	rm -rf ./bin/linux_arm/linux_arm
 
 .PHONY: image
 image: build-linux-amd64 build-linux-armv6 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ build-linux-amd64:
 .PHONY: build-linux-armv6
 build-linux-armv6:
 	make build OS=linux ARCH=arm
+	mv $$(pwd)/bin/linux_arm/linux_arm/* $$(pwd)/bin/linux_arm
+	rm -rf $$(pwd)/bin/linux_arm/linux_arm
 
 .PHONY: image
 image: build-linux-amd64 build-linux-armv6 

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,6 @@ build-linux-amd64:
 
 .PHONY: build-linux-armv6
 build-linux-armv6:
-	whoami
-	mkdir -p ./bin/linux_arm/linux_arm
 	make build OS=linux ARCH=arm
 	cp -f ./bin/linux_arm/linux_arm/kube-mgmt ./bin/linux_arm
 

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,7 @@ build-linux-amd64:
 .PHONY: build-linux-armv6
 build-linux-armv6:
 	make build OS=linux ARCH=arm
-	chown -R $(id -u):$(id -g) ./bin
-	mv ./bin/linux_arm/linux_arm/* ./bin/linux_arm
-	rm -rf ./bin/linux_arm/linux_arm
+	cp ./bin/linux_arm/linux_arm/* ./bin/linux_arm
 
 .PHONY: image
 image: build-linux-amd64 build-linux-armv6 

--- a/build/build.sh
+++ b/build/build.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-GOARCH=${ARCH} go install -ldflags "-X ${PKG}/pkg/version.Version=${VERSION} -X ${PKG}/pkg/version.Git=${COMMIT}" ./cmd/kube-mgmt/.../
+go install -ldflags "-X ${PKG}/pkg/version.Version=${VERSION} -X ${PKG}/pkg/version.Git=${COMMIT}" ./cmd/kube-mgmt/.../

--- a/build/build.sh
+++ b/build/build.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-go install -ldflags "-X ${PKG}/pkg/version.Version=${VERSION} -X ${PKG}/pkg/version.Git=${COMMIT}" ./cmd/kube-mgmt/.../
+GOARCH=${ARCH} go install -ldflags "-X ${PKG}/pkg/version.Version=${VERSION} -X ${PKG}/pkg/version.Git=${COMMIT}" ./cmd/kube-mgmt/.../

--- a/build/travis-utils.sh
+++ b/build/travis-utils.sh
@@ -15,5 +15,5 @@ function is_travis_release_env() {
   #   return 0
   # fi
   # return 1
-  return 0
+  return 1
 }

--- a/build/travis-utils.sh
+++ b/build/travis-utils.sh
@@ -1,10 +1,11 @@
 # Travis-CI sets TRAVIS_PULL_REQUEST=false when the build is triggered for
 # changes pushed into github.com/open-policy-agent/opa.
 function is_travis_push_env() {
-    if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-        return 0
-    fi
-    return 1
+    # if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    #     return 0
+    # fi
+    # return 1
+    return 0
 }
 
 # Travis-CI sets TRAVIS_TAG=<tag> when the build is triggered for a tag.
@@ -15,5 +16,5 @@ function is_travis_release_env() {
   #   return 0
   # fi
   # return 1
-  return 1
+  return 0
 }

--- a/build/travis-utils.sh
+++ b/build/travis-utils.sh
@@ -11,8 +11,9 @@ function is_travis_push_env() {
 # If the tag matches the source version then we can assume this is build is
 # for a release.
 function is_travis_release_env() {
-  if [ "$TRAVIS_TAG" = "v$(make version)" ]; then
-    return 0
-  fi
-  return 1
+  # if [ "$TRAVIS_TAG" = "v$(make version)" ]; then
+  #   return 0
+  # fi
+  # return 1
+  return 0
 }

--- a/build/travis-utils.sh
+++ b/build/travis-utils.sh
@@ -1,10 +1,9 @@
 # Travis-CI sets TRAVIS_PULL_REQUEST=false when the build is triggered for
 # changes pushed into github.com/open-policy-agent/opa.
 function is_travis_push_env() {
-    # if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-    #     return 0
-    # fi
-    # return 1
+    if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+        return 0
+    fi
     return 1
 }
 
@@ -12,9 +11,8 @@ function is_travis_push_env() {
 # If the tag matches the source version then we can assume this is build is
 # for a release.
 function is_travis_release_env() {
-  # if [ "$TRAVIS_TAG" = "v$(make version)" ]; then
-  #   return 0
-  # fi
-  # return 1
-  return 0
+  if [ "$TRAVIS_TAG" = "v$(make version)" ]; then
+    return 0
+  fi
+  return 1
 }

--- a/build/travis-utils.sh
+++ b/build/travis-utils.sh
@@ -5,7 +5,7 @@ function is_travis_push_env() {
     #     return 0
     # fi
     # return 1
-    return 0
+    return 1
 }
 
 # Travis-CI sets TRAVIS_TAG=<tag> when the build is triggered for a tag.


### PR DESCRIPTION
Modified the build process to build amd64 and arm/v6 architectures.

Closes #69

The build process uses dockers buildx functionality to build multi architecture images.

The process builds the code for amd64 and arm. 

Docker images are built for amd64 and arm/v6.

Docker images are pushed to docker hub and a docker manifest created that refers to the amd64 and arm/v6 architectures.

A latest manifest is created and pushed to docker hub.