### PR TITLE
arm support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,18 @@ go:
 - 1.8
 services:
 - docker
+# To use docker buildx for multi architexture builds, the latest version of
+# docker must be installed and the experimental features enabled.
+# Refer to: https://medium.com/@quentin.mcgaw/cross-architecture-docker-builds-with-travis-ci-arm-s390x-etc-8f754e20aaef
+before_install:
+- curl -fsSL https://get.docker.com | sh
+- echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+- mkdir -p $HOME/.docker
+- echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
+- sudo service docker start
+install:
+- docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+- docker buildx create --name xbuilder --use
 after_success:
 - source ./build/travis-utils.sh
 - if is_travis_push_env; then docker login -u $DOCKER_USER -p $DOCKER_PASSWORD; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine
 
 MAINTAINER Torin Sandall torinsandall@gmail.com
 
-ADD bin/linux_amd64/kube-mgmt /kube-mgmt
+ARG SOURCE=bin/linux_amd64/
+
+ADD ${SOURCE}/kube-mgmt /kube-mgmt
 
 USER 1000
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PKG := github.com/open-policy-agent/kube-mgmt
 REGISTRY ?= openpolicyagent
 VERSION := 0.12-dev
 ARCH := amd64
+OS := linux
 COMMIT := $(shell ./build/get-build-commit.sh)
 
 IMAGE := $(REGISTRY)/$(BIN)
@@ -17,16 +18,24 @@ build:
 	docker run -it \
 		-v $$(pwd)/.go:/go \
 		-v $$(pwd):/go/src/$(PKG) \
-		-v $$(pwd)/bin/linux_$(ARCH):/go/bin \
-		-v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static \
+		-v $$(pwd)/bin/$(OS)_$(ARCH):/go/bin \
+		-v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/$(OS)_$(ARCH)_static \
 		-w /go/src/$(PKG) \
 		$(BUILD_IMAGE) \
-		/bin/sh -c "ARCH=$(ARCH) VERSION=$(VERSION) COMMIT=$(COMMIT) PKG=$(PKG) ./build/build.sh"
+		/bin/sh -c "GOOS=$(OS) GOARCH=$(ARCH) VERSION=$(VERSION) COMMIT=$(COMMIT) PKG=$(PKG) ./build/build.sh"
+
+.PHONY: build-linux-amd64
+build-linux-amd64:
+	make build OS=linux ARCH=amd64
+
+.PHONY: build-linux-armv6
+build-linux-armv6:
+	make build OS=linux ARCH=arm
 
 .PHONY: image
-image: build
-	docker build -t $(IMAGE):$(VERSION) -f Dockerfile .
-	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest
+image: build-linux-amd64 build-linux-armv6 
+	docker buildx build -t $(IMAGE):$(VERSION)-linux-amd64 -f Dockerfile --platform linux/amd64 --build-arg SOURCE=bin/linux_amd64/ .
+	docker buildx build -t $(IMAGE):$(VERSION)-linux-armv6 -f Dockerfile --platform linux/arm/v6 --build-arg SOURCE=bin/linux_arm/ .
 
 .PHONY: clean
 clean:
@@ -45,11 +54,16 @@ up: image undeploy deploy
 
 .PHONY: push
 push:
-	docker push $(IMAGE):$(VERSION)
+	docker push $(IMAGE):$(VERSION)-linux-amd64
+	docker push $(IMAGE):$(VERSION)-linux-armv6
+
+	docker manifest create $(IMAGE):$(VERSION) $(IMAGE):$(VERSION)-linux-amd64 $(IMAGE):$(VERSION)-linux-armv6
+	docker manifest push --purge $(IMAGE):$(VERSION)
 
 .PHONY: push-latest
 push-latest:
-	docker push $(IMAGE):latest
+	docker manifest create $(IMAGE):latest $(IMAGE):$(VERSION)-linux-amd64 $(IMAGE):$(VERSION)-linux-armv6
+	docker manifest push --purge $(IMAGE):latest
 
 .PHONY: version
 version:


### PR DESCRIPTION
Modified the build process to build amd64 and arm/v6 architectures.

Closes #69

The build process uses dockers buildx functionality to build multi architecture images.

The process builds the code for amd64 and arm.

Docker images are built for amd64 and arm/v6.

Docker images are pushed to docker hub and a docker manifest created that refers to the amd64 and arm/v6 architectures.

A latest manifest is created and pushed to docker hub.