### PR TITLE
fix deployment manifest

### DIFF
--- a/manifests/deployment.yml
+++ b/manifests/deployment.yml
@@ -40,11 +40,14 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 ---
 # Deploy OPA and kube-mgmt.
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: opa
 spec:
+  selector:
+    matchLabels:
+      app: opa
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
- update deployment apiVersion to apps/v1 (available since 1.9, today we're in 1.18)
- add missing label selector