### PR TITLE
OPA Helm chart migration

### DIFF
--- a/.github/workflows/opa-helm-chart-release.yaml
+++ b/.github/workflows/opa-helm-chart-release.yaml
@@ -1,0 +1,35 @@
+name: opa_helm_chart_release
+on:
+  push:
+    paths-ignore:
+      - ".github/workflows/website.yaml"
+      - "docs/**"
+      - "logo/**"
+      - "examples/**"
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - ".github/workflows/website.yaml"
+      - "docs/**"
+      - "logo/**"
+      - "examples/**"
+      - "**.md"
+
+jobs:
+  tagged-release:
+    name: "Tagged Release"
+    runs-on: "ubuntu-latest"
+    if: startsWith(github.ref, 'refs/heads/opa-helm-chart-migration') && github.repository == 'open-policy-agent/kube-mgmt'
+    # if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-policy-agent/kube-mgmt'
+    timeout-minutes: 30
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Publish Helm chart
+        uses: stefanprodan/helm-gh-pages@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: charts
+          target_dir: charts
+          linting: off

--- a/.github/workflows/opa-helm-chart-release.yaml
+++ b/.github/workflows/opa-helm-chart-release.yaml
@@ -2,24 +2,17 @@ name: opa_helm_chart_release
 on:
   push:
     paths-ignore:
-      - ".github/workflows/website.yaml"
       - "docs/**"
       - "logo/**"
       - "examples/**"
       - "**.md"
-  pull_request:
-    paths-ignore:
-      - ".github/workflows/website.yaml"
-      - "docs/**"
-      - "logo/**"
-      - "examples/**"
-      - "**.md"
+    tags:
+      - 'v*'
 
 jobs:
   tagged-release:
     name: "Tagged Release"
     runs-on: "ubuntu-latest"
-    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-policy-agent/kube-mgmt'
     timeout-minutes: 30
     steps:
       - name: Check out code

--- a/.github/workflows/opa-helm-chart-release.yaml
+++ b/.github/workflows/opa-helm-chart-release.yaml
@@ -19,8 +19,7 @@ jobs:
   tagged-release:
     name: "Tagged Release"
     runs-on: "ubuntu-latest"
-    if: startsWith(github.ref, 'refs/heads/opa-helm-chart-migration') && github.repository == 'open-policy-agent/kube-mgmt'
-    # if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-policy-agent/kube-mgmt'
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-policy-agent/kube-mgmt'
     timeout-minutes: 30
     steps:
       - name: Check out code

--- a/.github/workflows/opa-helm-chart-release.yaml
+++ b/.github/workflows/opa-helm-chart-release.yaml
@@ -19,9 +19,5 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Publish Helm chart
-        uses: stefanprodan/helm-gh-pages@v1.2.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          charts_dir: charts
-          target_dir: charts
-          linting: off
+        run: |
+          build/helm-gh-pages.sh "${{ secrets.GITHUB_TOKEN }}" "" "" "" "" "" "charts" "" "off"

--- a/build/helm-gh-pages.sh
+++ b/build/helm-gh-pages.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Stefan Prodan. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+
+GITHUB_TOKEN=$1
+CHARTS_DIR=$2
+CHARTS_URL=$3
+OWNER=$4
+REPOSITORY=$5
+BRANCH=$6
+TARGET_DIR=$7
+HELM_VERSION=$8
+LINTING=$9
+
+CHARTS=()
+CHARTS_TMP_DIR=$(mktemp -d)
+REPO_ROOT=$(git rev-parse --show-toplevel)
+REPO_URL=""
+
+main() {
+  if [[ -z "$HELM_VERSION" ]]; then
+      HELM_VERSION="3.3.0"
+  fi
+
+  if [[ -z "$CHARTS_DIR" ]]; then
+      CHARTS_DIR="charts"
+  fi
+
+  if [[ -z "$OWNER" ]]; then
+      OWNER=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+  fi
+
+  if [[ -z "$REPOSITORY" ]]; then
+      REPOSITORY=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+  fi
+
+  if [[ -z "$BRANCH" ]]; then
+      BRANCH="gh-pages"
+  fi
+
+  if [[ -z "$TARGET_DIR" ]]; then
+    TARGET_DIR="."
+  fi
+
+  if [[ -z "$CHARTS_URL" ]]; then
+      CHARTS_URL="https://${OWNER}.github.io/${REPOSITORY}"
+  fi
+
+  if [[ "$TARGET_DIR" != "." ]]; then
+    CHARTS_URL="${CHARTS_URL}/${TARGET_DIR}"
+  fi
+
+  if [[ -z "$REPO_URL" ]]; then
+      REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPOSITORY}"
+  fi
+
+  locate
+  download
+  dependencies
+  if [[ "$LINTING" != "off" ]]; then
+    lint
+  fi
+  package
+  upload
+}
+
+locate() {
+  for dir in $(find "${CHARTS_DIR}" -type d -mindepth 1 -maxdepth 1); do
+    if [[ -f "${dir}/Chart.yaml" ]]; then
+      CHARTS+=("${dir}")
+      echo "Found chart directory ${dir}"
+    else
+      echo "Ignoring non-chart directory ${dir}"
+    fi
+  done
+}
+
+download() {
+  tmpDir=$(mktemp -d)
+
+  pushd $tmpDir >& /dev/null
+
+  curl -sSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar xz
+  sudo cp linux-amd64/helm /usr/local/bin/helm
+
+  popd >& /dev/null
+  rm -rf $tmpDir
+}
+
+dependencies() {
+  for chart in ${CHARTS[@]}; do
+    helm dependency update "${chart}"
+  done
+}
+
+lint() {
+  helm lint ${CHARTS[*]}
+}
+
+package() {
+  helm package ${CHARTS[*]} --destination ${CHARTS_TMP_DIR}
+}
+
+upload() {
+  tmpDir=$(mktemp -d)
+  pushd $tmpDir >& /dev/null
+
+  git clone ${REPO_URL}
+  cd ${REPOSITORY}
+  git config user.name "${GITHUB_ACTOR}"
+  git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+  git remote set-url origin ${REPO_URL}
+  git checkout ${BRANCH}
+
+  charts=$(cd ${CHARTS_TMP_DIR} && ls *.tgz | xargs)
+
+  mkdir -p ${TARGET_DIR}
+  mv -f ${CHARTS_TMP_DIR}/*.tgz ${TARGET_DIR}
+
+  if [[ -f "${TARGET_DIR}/index.yaml" ]]; then
+    echo "Found index, merging changes"
+    helm repo index ${TARGET_DIR} --url ${CHARTS_URL} --merge "${TARGET_DIR}/index.yaml"
+  else
+    echo "No index found, generating a new one"
+    helm repo index ${TARGET_DIR} --url ${CHARTS_URL}
+  fi
+
+  git add ${TARGET_DIR}
+  git commit -m "Publish $charts"
+  git push origin ${BRANCH}
+
+  popd >& /dev/null
+  rm -rf $tmpDir
+}
+
+main

--- a/charts/opa/Chart.yaml
+++ b/charts/opa/Chart.yaml
@@ -1,16 +1,14 @@
 apiVersion: v1
 appVersion: 0.15.1
-description: Open source, general-purpose policy engine. Enforce fine-grained invariants over arbitrary Kubernetes resources.
+description: DEPRECATED - Open source, general-purpose policy engine. Enforce fine-grained invariants over arbitrary Kubernetes resources.
 name: opa
 keywords:
 - opa
 - admission control
 - policy
-version: 1.14.0
+version: 1.14.6
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:
 - https://github.com/open-policy-agent/opa
-maintainers:
-- name: tsandall
-  email: torinsandall@gmail.com
+deprecated: true

--- a/charts/opa/Chart.yaml
+++ b/charts/opa/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 0.15.1
-description: DEPRECATED - Open source, general-purpose policy engine. Enforce fine-grained invariants over arbitrary Kubernetes resources.
+description: Open source, general-purpose policy engine. Enforce fine-grained invariants over arbitrary Kubernetes resources.
 name: opa
 keywords:
 - opa
@@ -11,4 +11,5 @@ home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:
 - https://github.com/open-policy-agent/opa
-deprecated: true
+- https://github.com/open-policy-agent/kube-mgmt
+deprecated: false

--- a/charts/opa/Chart.yaml
+++ b/charts/opa/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+appVersion: 0.15.1
+description: Open source, general-purpose policy engine. Enforce fine-grained invariants over arbitrary Kubernetes resources.
+name: opa
+keywords:
+- opa
+- admission control
+- policy
+version: 1.14.0
+home: https://www.openpolicyagent.org
+icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
+sources:
+- https://github.com/open-policy-agent/opa
+maintainers:
+- name: tsandall
+  email: torinsandall@gmail.com

--- a/charts/opa/OWNERS
+++ b/charts/opa/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- tsandall
+- timothyhinrichs
+reviewers:
+- tsandall
+- timothyhinrichs
+- patrick-east

--- a/charts/opa/OWNERS
+++ b/charts/opa/OWNERS
@@ -1,7 +1,0 @@
-approvers:
-- tsandall
-- timothyhinrichs
-reviewers:
-- tsandall
-- timothyhinrichs
-- patrick-east

--- a/charts/opa/README.md
+++ b/charts/opa/README.md
@@ -1,7 +1,16 @@
+# ⚠️ Repo Archive Notice
+
+As of Nov 13, 2020, charts in this repo will no longer be updated.
+For more information, see the Helm Charts [Deprecation and Archive Notice](https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice), and [Update](https://helm.sh/blog/charts-repo-deprecation/).
+
 # OPA
 
 [OPA](https://www.openpolicyagent.org) is an open source general-purpose policy
 engine designed for cloud-native environments.
+
+## DEPRECATION NOTICE
+
+This chart is deprecated and no longer supported.
 
 ## Prerequisites
 
@@ -69,6 +78,7 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `podDisruptionBudget.enabled` | Enables creation of a PodDisruptionBudget for OPA. | `false` |
 | `podDisruptionBudget.minAvailable` | Sets the minimum number of pods to be available. Cannot be set at the same time as maxUnavailable. | `1` |
 | `podDisruptionBudget.maxUnavailable` | Sets the maximum number of pods to be unavailable. Cannot be set at the same time as minAvailable. | Unset |
+| `hostNetwork.enabled` | Use hostNetwork setting on OPA pod | `false` |
 | `image` | OPA image to deploy. | `openpolicyagent/opa` |
 | `imageTag` | OPA image tag to deploy. | See [values.yaml](values.yaml) |
 | `port` | Port in the pod to which OPA will bind itself. | `443` |
@@ -83,6 +93,7 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `livenessProbe` | HTTP liveness probe for OPA container. | See [values.yaml](values.yaml) |
 | `opa` | OPA configuration. | See [values.yaml](values.yaml) |
 | `mgmt` | kube-mgmt configuration. | See [values.yaml](values.yaml) |
+| `mgmt.port` | kube-mgmt/prometheus port used to communicate with opa. | See [values.yaml](values.yaml) |
 | `sar.resources` | CPU and memory limits for the sar container. | `{}` |
 | `priorityClassName` | The name of the priorityClass for the pods. | Unset |
 | `prometheus.enabled` | Flag to expose the `/metrics` endpoint to be scraped. | `false` |
@@ -94,6 +105,7 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `timeoutSeconds` | Timeout for a webhook call in seconds. | `` |
 | `securityContext` | Security context for the containers | `{enabled: false, runAsNonRoot: true, runAsUser: 1}` |
 | `deploymentStrategy` | Specify deployment spec rollout strategy | `{}` |
+| `extraArgs` | Additional arguments to be added to the opa container | `[]` |
 | `extraContainers` | Additional containers to be added to the deployment | `[]` |
 | `extraVolumes` | Additional volumes to be added to the deployment | `[]` |
 | `extraPorts` | Additional ports to OPA service. Useful to expose `extraContainer` ports. | `[]` |

--- a/charts/opa/README.md
+++ b/charts/opa/README.md
@@ -22,7 +22,13 @@ If you just want to see something run, install the chart without any
 configuration.
 
 ```bash
-helm install stable/opa
+$ helm repo add open-policy-agent https://open-policy-agent.github.io/kube-mgmt/charts
+"open-policy-agent" has been added to your repositories
+$ helm repo update
+...Successfully got an update from the "open-policy-agent" chart repository
+...Successfully got an update from the "stable" chart repository
+Update Complete. ⎈Happy Helming!⎈
+$ helm install stable/opa
 ```
 
 Once installed, the OPA will download a sample bundle from

--- a/charts/opa/README.md
+++ b/charts/opa/README.md
@@ -1,0 +1,99 @@
+# OPA
+
+[OPA](https://www.openpolicyagent.org) is an open source general-purpose policy
+engine designed for cloud-native environments.
+
+## Prerequisites
+
+- Kubernetes 1.9 (or newer) for validating and mutating webhook admission
+  controller support.
+- Optional, cert-manager (https://docs.cert-manager.io/en/latest/)
+
+## Overview
+
+This helm chart installs OPA as a [Kubernetes admission
+controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/).
+Using OPA, you can enforce fine-grained invariants over arbitrary resources in
+your Kubernetes cluster.
+
+## Kick the tires
+
+If you just want to see something run, install the chart without any
+configuration.
+
+```bash
+helm install stable/opa
+```
+
+Once installed, the OPA will download a sample bundle from
+https://www.openpolicyagent.org. The sample bundle contains a simple policy that
+restricts the hostnames that can be specified on Ingress objects created in the
+`opa-example` namespace. You can download the bundle and inspect it yourself:
+
+```bash
+mkdir example && cd example
+curl -s -L https://www.openpolicyagent.org/bundles/kubernetes/admission | tar xzv
+```
+
+See the [NOTES.txt](./templates/NOTES.txt) file for examples of how to exercise
+the admission controller.
+
+## Configuration
+
+All configuration settings are contained and described in
+[values.yaml](values.yaml).
+
+You should set the URL and credentials for the OPA to use to download policies.
+The URL should identify an HTTP endpoint that implements the [OPA Bundle
+API](https://www.openpolicyagent.org/docs/bundles.html).
+
+- `opa.services.controller.url` specifies the base URL of the OPA control plane.
+
+- `opa.services.controller.credentials.bearer.token` specifies a bearer token
+  for the OPA to use to authenticate with the control plane.
+
+For more information on OPA-specific configuration see the [OPA Configuration
+Reference](https://www.openpolicyagent.org/docs/configuration.html).
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `certManager.enabled` | Setup the Webhook using cert-manager | `false` |
+| `admissionControllerKind` | Type of admission controller to install. | `ValidatingWebhookConfiguration` |
+| `admissionControllerFailurePolicy` | Fail-open (`Ignore`) or fail-closed (`Fail`)? | `Ignore` |
+| `admissionControllerRules` | Types of operations resources to check. | `*` |
+| `admissionControllerNamespaceSelector` | Namespace selector for the admission controller | See [values.yaml](values.yaml) |
+| `generateAdmissionControllerCerts` | Auto-generate TLS certificates for admission controller. | `true` |
+| `admissionControllerCA` | Manually set admission controller certificate CA. | Unset |
+| `admissionControllerCert` | Manually set admission controller certificate. | Unset |
+| `admissionControllerKey` | Manually set admission controller key. | Unset |
+| `podDisruptionBudget.enabled` | Enables creation of a PodDisruptionBudget for OPA. | `false` |
+| `podDisruptionBudget.minAvailable` | Sets the minimum number of pods to be available. Cannot be set at the same time as maxUnavailable. | `1` |
+| `podDisruptionBudget.maxUnavailable` | Sets the maximum number of pods to be unavailable. Cannot be set at the same time as minAvailable. | Unset |
+| `image` | OPA image to deploy. | `openpolicyagent/opa` |
+| `imageTag` | OPA image tag to deploy. | See [values.yaml](values.yaml) |
+| `port` | Port in the pod to which OPA will bind itself. | `443` |
+| `logLevel` | Log level that OPA outputs at, (`debug`, `info` or `error`) | `info` |
+| `logFormat` | Log format that OPA produces (`text` or `json`) | `text` |
+| `replicas` | Number of admission controller replicas to deploy. | `1` |
+| `affinity` | Pod/Node affinity and anti-affinity | `{}` |
+| `tolerations` | List of node taint tolerations. | `[]` |
+| `nodeSelector` | Node labels for pod assignment. | `{}` |
+| `resources` | CPU and memory limits for OPA container. | `{}` |
+| `readinessProbe` | HTTP readiness probe for OPA container. | See [values.yaml](values.yaml) |
+| `livenessProbe` | HTTP liveness probe for OPA container. | See [values.yaml](values.yaml) |
+| `opa` | OPA configuration. | See [values.yaml](values.yaml) |
+| `mgmt` | kube-mgmt configuration. | See [values.yaml](values.yaml) |
+| `sar.resources` | CPU and memory limits for the sar container. | `{}` |
+| `priorityClassName` | The name of the priorityClass for the pods. | Unset |
+| `prometheus.enabled` | Flag to expose the `/metrics` endpoint to be scraped. | `false` |
+| `serviceMonitor.enabled` | if `true`, creates a Prometheus Operator ServiceMonitor | `false` |
+| `serviceMonitor.interval` | Interval that Prometheus scrapes Envoy metrics | `15s` |
+| `serviceMonitor.namespace` | Namespace which the operated Prometheus is running in | `` |
+| `annotations` | Annotations to be added to the deployment template. | `{}` |
+| `bootstrapPolicies` | Bootstrap policies to be loaded during OPA startup. | `{}` |
+| `timeoutSeconds` | Timeout for a webhook call in seconds. | `` |
+| `securityContext` | Security context for the containers | `{enabled: false, runAsNonRoot: true, runAsUser: 1}` |
+| `deploymentStrategy` | Specify deployment spec rollout strategy | `{}` |
+| `extraContainers` | Additional containers to be added to the deployment | `[]` |
+| `extraVolumes` | Additional volumes to be added to the deployment | `[]` |
+| `extraPorts` | Additional ports to OPA service. Useful to expose `extraContainer` ports. | `[]` |

--- a/charts/opa/README.md
+++ b/charts/opa/README.md
@@ -1,16 +1,7 @@
-# ⚠️ Repo Archive Notice
-
-As of Nov 13, 2020, charts in this repo will no longer be updated.
-For more information, see the Helm Charts [Deprecation and Archive Notice](https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice), and [Update](https://helm.sh/blog/charts-repo-deprecation/).
-
 # OPA
 
-[OPA](https://www.openpolicyagent.org) is an open source general-purpose policy
+[OPA](https://www.openpolicyagent.org) is an open-source general-purpose policy
 engine designed for cloud-native environments.
-
-## DEPRECATION NOTICE
-
-This chart is deprecated and no longer supported.
 
 ## Prerequisites
 

--- a/charts/opa/templates/NOTES.txt
+++ b/charts/opa/templates/NOTES.txt
@@ -1,0 +1,59 @@
+Please wait while the OPA is deployed on your cluster.
+
+For example policies that you can enforce with OPA see https://www.openpolicyagent.org.
+
+If you installed this chart with the default values, you can exercise the sample policy.
+
+# 1. Create a namespace called "opa-example"
+
+kubectl create namespace opa-example
+
+# 2. Create an Ingress in the "opa-example" namespace that complies with the policy.
+
+cat > ingress-ok.yaml <<EOF
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ingress-ok
+spec:
+  rules:
+  - host: signin.dev.acmecorp.com
+    http:
+      paths:
+      - backend:
+          serviceName: nginx
+          servicePort: 80
+EOF
+
+kubectl -n opa-example create -f ingress-ok.yaml
+
+# 3. Try to create an Ingress in the "opa-example" namespace that violates the policy.
+
+cat > ingress-bad.yaml <<EOF
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ingress-ok
+spec:
+  rules:
+  - host: signin.acmecorp.com
+    http:
+      paths:
+      - backend:
+          serviceName: nginx
+          servicePort: 80
+EOF
+
+kubectl -n opa-example create -f ingress-bad.yaml
+
+If you want to turn off authz for debugging purposes, you can do so by upgrading the chart like so:
+helm upgrade {{ .Release.Name }} stable/opa --reuse-values --set authz.enabled=false
+
+You can query OPA to see the policies it has loaded (you will need to turn off authz as described above):
+
+export OPA_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "opa.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+
+kubectl port-forward $OPA_POD_NAME 8080:443 --namespace {{ .Release.Namespace }}
+
+curl -k -s https://localhost:8080/v1/policies | jq -r '.result[].raw'
+

--- a/charts/opa/templates/_helpers.tpl
+++ b/charts/opa/templates/_helpers.tpl
@@ -1,0 +1,95 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "opa.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "opa.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "opa.sarfullname" -}}
+{{- $name := (include "opa.fullname" . | trunc 59 | trimSuffix "-") -}}
+{{- printf "%s-sar" $name -}}
+{{- end -}}
+
+{{- define "opa.mgmtfullname" -}}
+{{- $name := (include "opa.fullname" . | trunc 58 | trimSuffix "-") -}}
+{{- printf "%s-mgmt" $name -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "opa.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Define standard labels for frequently used metadata.
+*/}}
+{{- define "opa.labels.standard" -}}
+app: {{ template "opa.fullname" . }}
+chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+release: "{{ .Release.Name }}"
+heritage: "{{ .Release.Service }}"
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "opa.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "opa.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "opa.selfSignedIssuer" -}}
+{{ printf "%s-selfsign" (include "opa.fullname" .) }}
+{{- end -}}
+
+{{- define "opa.rootCAIssuer" -}}
+{{ printf "%s-ca" (include "opa.fullname" .) }}
+{{- end -}}
+
+{{- define "opa.rootCACertificate" -}}
+{{ printf "%s-ca" (include "opa.fullname" .) }}
+{{- end -}}
+
+{{- define "opa.servingCertificate" -}}
+{{ printf "%s-webhook-tls" (include "opa.fullname" .) }}
+{{- end -}}
+
+{{/*
+Detect the version of cert manager crd that is installed
+Error if CRD is not available
+*/}}
+{{- define "opa.certManagerApiVersion" -}}
+{{- if (.Capabilities.APIVersions.Has "cert-manager.io/v1alpha3") -}}
+cert-manager.io/v1alpha3
+{{- else if (.Capabilities.APIVersions.Has "cert-manager.io/v1alpha2") -}}
+cert-manager.io/v1alpha2
+{{- else if (.Capabilities.APIVersions.Has "certmanager.k8s.io/v1alpha1") -}}
+certmanager.k8s.io/v1alpha1
+{{- else  -}}
+{{- fail "cert-manager CRD does not appear to be installed" }}
+{{- end -}}
+{{- end -}}

--- a/charts/opa/templates/deployment.yaml
+++ b/charts/opa/templates/deployment.yaml
@@ -31,6 +31,12 @@ spec:
         app: {{ template "opa.fullname" . }}
       name: {{ template "opa.fullname" . }}
     spec:
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+{{- end }}
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
@@ -72,9 +78,18 @@ spec:
             - name: bootstrap
               mountPath: /bootstrap
 {{- end }}
-
+{{- if .Values.hostNetwork.enabled }}
+      hostNetwork: true
+{{- end }}
       containers:
         - name: opa
+          ports:
+          - name: https
+            containerPort: {{ .Values.port }}
+{{- if .Values.prometheus.enabled }}
+          - name: http
+            containerPort: {{ .Values.mgmt.port }}
+{{- end }}
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           resources:
@@ -96,12 +111,15 @@ spec:
             - "--ignore=.*"
 {{- end }}
 {{- if .Values.prometheus.enabled }}
-            - "--addr=http://0.0.0.0:8181"
+            - "--addr=http://0.0.0.0:{{ .Values.mgmt.port }}"
 {{- else if .Values.mgmt.enabled }}
-            - "--addr=http://127.0.0.1:8181"
+            - "--addr=http://127.0.0.1:{{ .Values.mgmt.port }}"
 {{- end }}
 {{- if or .Values.authz.enabled .Values.bootstrapPolicies }}
             - "/bootstrap"
+{{- end }}
+{{- range .Values.extraArgs }}
+            - {{ . }}
 {{- end }}
           volumeMounts:
             - name: certs
@@ -131,7 +149,7 @@ spec:
 {{- if .Values.authz.enabled }}
             - --opa-auth-token-file=/bootstrap/mgmt-token
 {{- end }}
-            - --opa-url=http://127.0.0.1:8181/v1
+            - --opa-url=http://127.0.0.1:{{ .Values.mgmt.port }}/v1
             - --replicate-path={{ .Values.mgmt.replicate.path }}
             - --enable-data={{ .Values.mgmt.data.enabled }}
             - --enable-policies={{ .Values.mgmt.configmapPolicies.enabled }}

--- a/charts/opa/templates/deployment.yaml
+++ b/charts/opa/templates/deployment.yaml
@@ -1,0 +1,202 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "opa.fullname" . }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "opa.fullname" . }}
+  {{- with .Values.deploymentStrategy }}
+  strategy:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+{{- if or .Values.generateAdmissionControllerCerts .Values.opa }}
+      annotations:
+{{- if .Values.generateAdmissionControllerCerts }}
+        checksum/certs: {{ include (print $.Template.BasePath "/webhookconfiguration.yaml") . | sha256sum }}
+{{- end }}
+{{- if .Values.opa }}
+        checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+{{- end }}
+{{- end }}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+      labels:
+        app: {{ template "opa.fullname" . }}
+      name: {{ template "opa.fullname" . }}
+    spec:
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
+{{- if or .Values.authz.enabled .Values.bootstrapPolicies}}
+      initContainers:
+        - name: initpolicy
+          image: {{ .Values.mgmt.image }}:{{ .Values.mgmt.imageTag }}
+          imagePullPolicy: {{ .Values.mgmt.imagePullPolicy }}
+          resources:
+{{ toYaml .Values.mgmt.resources | indent 12 }}
+          command:
+          - /bin/sh
+          - -c
+          - |
+{{- if .Values.authz.enabled }}
+            tr -dc 'A-F0-9' < /dev/urandom | dd bs=1 count=32 2>/dev/null > /bootstrap/mgmt-token
+            TOKEN=`cat /bootstrap/mgmt-token`
+            cat > /bootstrap/authz.rego <<EOF
+            package system.authz
+            default allow = false
+            # Allow anonymous access to the default policy decision.
+            allow { input.path = [""]; input.method = "POST" }
+            allow { input.path = [""]; input.method = "GET" }
+            # This is only used for health check in liveness and readiness probe
+            allow { input.path = ["health"]; input.method = "GET" }
+{{- if .Values.prometheus.enabled }}
+            # This allows metrics to be scraped by prometheus
+            allow { input.path = ["metrics"]; input.method = "GET" }
+{{- end }}
+            allow { input.identity == "$TOKEN" }
+            EOF
+{{- end }}
+{{- range $policyName, $policy := .Values.bootstrapPolicies }}
+            cat > /bootstrap/{{ $policyName }}.rego <<EOF
+{{ $policy | indent 12 }}
+            EOF
+{{- end }}
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /bootstrap
+{{- end }}
+
+      containers:
+        - name: opa
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          args:
+            - "run"
+            - "--server"
+{{- if .Values.opa }}
+            - "--config-file=/config/config.yaml"
+{{- end }}
+            - "--tls-cert-file=/certs/tls.crt"
+            - "--tls-private-key-file=/certs/tls.key"
+            - "--addr=0.0.0.0:{{ .Values.port }}"
+            - "--log-level={{ .Values.logLevel }}"
+            - "--log-format={{ .Values.logFormat }}"
+{{- if .Values.authz.enabled }}
+            - "--authentication=token"
+            - "--authorization=basic"
+            - "--ignore=.*"
+{{- end }}
+{{- if .Values.prometheus.enabled }}
+            - "--addr=http://0.0.0.0:8181"
+{{- else if .Values.mgmt.enabled }}
+            - "--addr=http://127.0.0.1:8181"
+{{- end }}
+{{- if or .Values.authz.enabled .Values.bootstrapPolicies }}
+            - "/bootstrap"
+{{- end }}
+          volumeMounts:
+            - name: certs
+              readOnly: true
+              mountPath: /certs
+{{- if .Values.opa }}
+            - name: config
+              readOnly: true
+              mountPath: /config
+{{- end }}
+{{- if or .Values.authz.enabled .Values.bootstrapPolicies }}
+            - name: bootstrap
+              readOnly: true
+              mountPath: /bootstrap
+{{- end }}
+          readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 12 }}
+          livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 12 }}
+{{- if .Values.mgmt.enabled }}
+        - name: mgmt
+          image: {{ .Values.mgmt.image }}:{{ .Values.mgmt.imageTag }}
+          imagePullPolicy: {{ .Values.mgmt.imagePullPolicy }}
+          resources:
+{{ toYaml .Values.mgmt.resources | indent 12 }}
+          args:
+{{- if .Values.authz.enabled }}
+            - --opa-auth-token-file=/bootstrap/mgmt-token
+{{- end }}
+            - --opa-url=http://127.0.0.1:8181/v1
+            - --replicate-path={{ .Values.mgmt.replicate.path }}
+            - --enable-data={{ .Values.mgmt.data.enabled }}
+            - --enable-policies={{ .Values.mgmt.configmapPolicies.enabled }}
+{{- if .Values.mgmt.configmapPolicies.enabled }}
+            - --policies={{ .Values.mgmt.configmapPolicies.namespaces | join "," }}
+            - --require-policy-label={{ .Values.mgmt.configmapPolicies.requireLabel }}
+{{- end }}
+{{- range .Values.mgmt.replicate.namespace }}
+            - --replicate={{ . }}
+{{- end }}
+{{- range .Values.mgmt.replicate.cluster }}
+            - --replicate-cluster={{ . }}
+{{- end }}
+{{- range .Values.mgmt.extraArgs }}
+            - {{ . }}
+{{- end }}
+{{- if or .Values.authz.enabled .Values.bootstrapPolicies }}
+          volumeMounts:
+            - name: bootstrap
+              readOnly: true
+              mountPath: /bootstrap
+{{- end }}
+{{- end }}
+{{- if .Values.sar.enabled }}
+        - name: sarproxy
+          image: {{ .Values.sar.image }}:{{ .Values.sar.imageTag }}
+          imagePullPolicy: {{ .Values.sar.imagePullPolicy }}
+          resources:
+{{ toYaml .Values.sar.resources | indent 12 }}
+          command:
+            - kubectl
+            - proxy
+            - --accept-paths=^/apis/authorization.k8s.io/v1/subjectaccessreviews$
+{{- end }}
+{{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 8}}
+{{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        {{- range $key, $val := .Values.securityContext }}
+        {{- if ne $key "enabled" }}
+        {{ $key }}: {{ toYaml $val | nindent 10 }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+      serviceAccountName: {{ template "opa.serviceAccountName" .}}
+      volumes:
+        - name: certs
+          secret:
+            secretName: {{ template "opa.fullname" . }}-cert
+{{- if .Values.opa }}
+        - name: config
+          secret:
+            secretName: {{ template "opa.fullname" . }}-config
+{{- end }}
+{{- if or .Values.authz.enabled .Values.bootstrapPolicies}}
+        - name: bootstrap
+          emptyDir: {}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8}}
+{{- end }}
+{{- end }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}

--- a/charts/opa/templates/mgmt-clusterrole.yaml
+++ b/charts/opa/templates/mgmt-clusterrole.yaml
@@ -1,0 +1,14 @@
+{{- if (and .Values.rbac.create .Values.mgmt.enabled) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "opa.name" . }}
+    chart: {{ template "opa.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: mgmt
+  name: {{ template "opa.mgmtfullname" . }}
+rules:
+{{ toYaml .Values.rbac.rules.cluster | indent 2 }}
+{{- end -}}

--- a/charts/opa/templates/mgmt-clusterrolebinding.yaml
+++ b/charts/opa/templates/mgmt-clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if (and .Values.rbac.create .Values.mgmt.enabled) -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "opa.name" . }}
+    chart: {{ template "opa.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: mgmt
+  name: {{ template "opa.mgmtfullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "opa.mgmtfullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "opa.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/opa/templates/poddisruptionbudget.yaml
+++ b/charts/opa/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "opa.fullname" . }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+spec:
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "opa.fullname" . }}
+{{- end }}

--- a/charts/opa/templates/sar-clusterrole.yaml
+++ b/charts/opa/templates/sar-clusterrole.yaml
@@ -1,0 +1,19 @@
+{{- if (and .Values.rbac.create .Values.sar.enabled) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "opa.name" . }}
+    chart: {{ template "opa.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: sar
+  name: {{ template "opa.sarfullname" . }}
+rules:
+  - apiGroups:
+      - "authorization.k8s.io"
+    resources:
+    - subjectaccessreviews
+    verbs:
+    - create
+{{- end -}}

--- a/charts/opa/templates/sar-clusterrolebinding.yaml
+++ b/charts/opa/templates/sar-clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if (and .Values.rbac.create .Values.sar.enabled) -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "opa.name" . }}
+    chart: {{ template "opa.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: sar
+  name: {{ template "opa.sarfullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "opa.sarfullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "opa.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/opa/templates/secrets.yaml
+++ b/charts/opa/templates/secrets.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.opa -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "opa.fullname" . }}-config
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+type: Opaque
+data:
+  config.yaml: {{ toYaml .Values.opa | b64enc }}
+{{- end -}}

--- a/charts/opa/templates/service.yaml
+++ b/charts/opa/templates/service.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "opa.fullname" . }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+spec:
+  selector:
+    app: {{ template "opa.fullname" . }}
+  ports:
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: {{ .Values.port }}
+{{- if .Values.extraPorts }}
+{{ toYaml .Values.extraPorts | indent 2}}
+{{- end }}

--- a/charts/opa/templates/service.yaml
+++ b/charts/opa/templates/service.yaml
@@ -12,6 +12,10 @@ spec:
     protocol: TCP
     port: 443
     targetPort: {{ .Values.port }}
+{{- if .Values.prometheus.enabled }}
+  - name: http
+    port: {{ .Values.mgmt.port }}
+{{- end }}
 {{- if .Values.extraPorts }}
 {{ toYaml .Values.extraPorts | indent 2}}
 {{- end }}

--- a/charts/opa/templates/serviceaccount.yaml
+++ b/charts/opa/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "opa.serviceAccountName" .}}
+  labels:
+    app: {{ template "opa.fullname" . }}
+    chart: {{ template "opa.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}

--- a/charts/opa/templates/servicemonitor.yaml
+++ b/charts/opa/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.prometheus.enabled .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: {{ template "opa.name" . }}
+    chart: {{ template "opa.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4}}
+    {{- end }}
+  name: {{ template "opa.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+spec:
+  endpoints:
+  - targetPort: 8181
+    interval: {{ .Values.serviceMonitor.interval }}
+    path: "/metrics"
+  jobLabel: {{ template "opa.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "opa.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/opa/templates/servicemonitor.yaml
+++ b/charts/opa/templates/servicemonitor.yaml
@@ -6,7 +6,9 @@ metadata:
     app: {{ template "opa.name" . }}
     chart: {{ template "opa.chart" . }}
     heritage: {{ .Release.Service }}
+    {{- if not .Values.serviceMonitor.additionalLabels.release }}
     release: {{ .Release.Name }}
+    {{- end }}
     {{- if .Values.serviceMonitor.additionalLabels }}
     {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4}}
     {{- end }}
@@ -16,15 +18,14 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - targetPort: 8181
+  - port: http
     interval: {{ .Values.serviceMonitor.interval }}
-    path: "/metrics"
   jobLabel: {{ template "opa.fullname" . }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "opa.name" . }}
+      app: {{ template "opa.fullname" . }}
       release: {{ .Release.Name }}
 {{- end }}

--- a/charts/opa/templates/webhookconfiguration.yaml
+++ b/charts/opa/templates/webhookconfiguration.yaml
@@ -1,0 +1,120 @@
+{{- $cn := printf "%s.%s.svc" ( include "opa.fullname" . ) .Release.Namespace }}
+{{- $ca := genCA "opa-admission-ca" 3650 -}}
+{{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+kind: {{ .Values.admissionControllerKind }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+metadata:
+  name: {{ template "opa.fullname" . }}
+  annotations:
+{{- if .Values.certManager.enabled }}
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace (include "opa.rootCACertificate" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace (include "opa.rootCACertificate" .) | quote }}
+{{- end }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+webhooks:
+  - name: webhook.openpolicyagent.org
+{{- with .Values.admissionControllerNamespaceSelector }}
+    namespaceSelector:
+{{ toYaml . | indent 6 }}
+{{ end }}
+    failurePolicy: {{ .Values.admissionControllerFailurePolicy }}
+    rules:
+{{ toYaml .Values.admissionControllerRules | indent 6 }}
+    clientConfig:
+{{ if not .Values.certManager.enabled }}
+{{ if .Values.generateAdmissionControllerCerts }}
+      caBundle: {{ b64enc $ca.Cert }}
+{{ else }}
+      caBundle: {{ b64enc .Values.admissionControllerCA }}
+{{ end }}
+{{ end }}
+      service:
+        name: {{ template "opa.fullname" . }}
+        namespace: {{ .Release.Namespace }}
+    sideEffects: {{ .Values.admissionControllerSideEffect }}
+{{ if .Values.timeoutSeconds }}
+    timeoutSeconds: {{ .Values.timeoutSeconds }}
+{{ end }}
+
+{{ if .Values.certManager.enabled }}
+---
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: {{ include "opa.certManagerApiVersion" . }}
+kind: Issuer
+metadata:
+  name: {{ include "opa.selfSignedIssuer" . }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+spec:
+  selfSigned: {}
+
+---
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: {{ include "opa.certManagerApiVersion" . }}
+kind: Certificate
+metadata:
+  name: {{ include "opa.rootCACertificate" . }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+spec:
+  secretName: {{ include "opa.rootCACertificate" . }}
+  duration: 43800h # 5y
+  issuerRef:
+    name: {{ include "opa.selfSignedIssuer" . }}
+  commonName: "ca.webhook.opa"
+  isCA: true
+
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: {{ include "opa.certManagerApiVersion" . }}
+kind: Issuer
+metadata:
+  name: {{ include "opa.rootCAIssuer" . }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+spec:
+  ca:
+    secretName: {{ include "opa.rootCACertificate" . }}
+
+---
+
+# Finally, generate a serving certificate for the webhook to use
+apiVersion: {{ include "opa.certManagerApiVersion" . }}
+kind: Certificate
+metadata:
+  name: {{ include "opa.servingCertificate" . }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+spec:
+  secretName: {{ template "opa.fullname" . }}-cert
+  duration: 8760h # 1y
+  issuerRef:
+    name: {{ include "opa.rootCAIssuer" . }}
+  dnsNames:
+  - {{ include "opa.fullname" . }}
+  - {{ include "opa.fullname" . }}.{{ .Release.Namespace }}
+  - {{ include "opa.fullname" . }}.{{ .Release.Namespace }}.svc
+{{ end }}
+{{- if not .Values.certManager.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "opa.fullname" . }}-cert
+  labels:
+    app: {{ template "opa.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+{{ if .Values.generateAdmissionControllerCerts }}
+  tls.crt: {{ b64enc $cert.Cert }}
+  tls.key: {{ b64enc $cert.Key }}
+{{ else }}
+  tls.crt: {{ b64enc .Values.admissionControllerCert }}
+  tls.key: {{ b64enc .Values.admissionControllerKey }}
+{{ end }}
+{{ end }}

--- a/charts/opa/values.yaml
+++ b/charts/opa/values.yaml
@@ -100,21 +100,33 @@ authz:
   # Mostly useful for debugging.
   enabled: true
 
+# Use hostNetwork setting on OPA pod
+hostNetwork:
+  enabled: false
+
 # Docker image and tag to deploy.
 image: openpolicyagent/opa
 imageTag: 0.15.1
 imagePullPolicy: IfNotPresent
+
+# One or more secrets to be used when pulling images
+imagePullSecrets: []
+# - registrySecretName
 
 # Port to which the opa pod will bind itself
 # NOTE IF you use a different port make sure it maches the ones in the readinessProbe
 # and livenessProbe
 port: 443
 
+extraArgs: []
+
 mgmt:
   enabled: true
   image: openpolicyagent/kube-mgmt
   imageTag: "0.10"
   imagePullPolicy: IfNotPresent
+# NOTE insecure http port conjointly used for mgmt access and prometheus metrics export
+  port: 8181
   extraArgs: []
   resources: {}
   data:

--- a/charts/opa/values.yaml
+++ b/charts/opa/values.yaml
@@ -1,0 +1,271 @@
+# Default values for opa.
+# -----------------------
+#
+# The 'opa' key embeds an OPA configuration file. See https://www.openpolicyagent.org/docs/configuration.html for more details.
+# Use 'opa: false' to disable the OPA configuration and rely on configmaps for policy loading.
+# See https://www.openpolicyagent.org/docs/latest/kubernetes-admission-control/#3-deploy-opa-on-top-of-kubernetes and the `mgmt.configmapPolicies` section below for more details.
+opa:
+  services:
+    controller:
+      url: 'https://www.openpolicyagent.org'
+  bundles:
+    quickstart:
+      service: controller
+      resource: /bundles/helm-kubernetes-quickstart
+  default_decision: /helm_kubernetes_quickstart/main
+
+# Setup the webhook using cert-manager
+certManager:
+  enabled: false
+
+# Expose the prometheus scraping endpoint
+prometheus:
+  enabled: false
+
+## ServiceMonitor consumed by prometheus-operator
+serviceMonitor:
+  ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+  enabled: false
+  interval: "15s"
+  ## Namespace in which the service monitor is created
+  # namespace: monitoring
+  # Added to the ServiceMonitor object so that prometheus-operator is able to discover it
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  additionalLabels: {}
+
+# Annotations in the deployment template
+annotations:
+  {}
+
+# Bootstrap policies to load upon startup
+# Define policies in the form of:
+# <policyName> : |-
+#   <regoBody>
+# For example, to mask the entire input body in the decision logs:
+# bootstrapPolicies:
+#   log: |-
+#     package system.log
+#     mask["/input"]
+bootstrapPolicies: {}
+
+# To enforce mutating policies, change to MutatingWebhookConfiguration.
+admissionControllerKind: ValidatingWebhookConfiguration
+
+# To _fail closed_ on failures, change to Fail. During initial testing, we
+# recommend leaving the failure policy as Ignore.
+admissionControllerFailurePolicy: Ignore
+
+# Adds a namespace selector to the admission controller webhook
+admissionControllerNamespaceSelector:
+  matchExpressions:
+    - {key: openpolicyagent.org/webhook, operator: NotIn, values: [ignore]}
+
+# SideEffectClass for the webhook, setting to None enables dry-run
+admissionControllerSideEffect: Unknown
+
+# To restrict the kinds of operations and resources that are subject to OPA
+# policy checks, see the settings below. By default, all resources and
+# operations are subject to OPA policy checks.
+admissionControllerRules:
+  - operations: ["*"]
+    apiGroups: ["*"]
+    apiVersions: ["*"]
+    resources: ["*"]
+
+# Controls a PodDisruptionBudget for the OPA pod. Suggested use if having opa
+# always running for admission control is important
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+# maxUnavailable: 1
+
+# The helm Chart will automatically generate a CA and server certificate for
+# the OPA. If you want to supply your own certificates, set the field below to
+# false and add the PEM encoded CA certificate and server key pair below.
+#
+# WARNING: The common name name in the server certificate MUST match the
+# hostname of the service that exposes the OPA to the apiserver. For example.
+# if the service name is created in the "default" nanamespace with name "opa"
+# the common name MUST be set to "opa.default.svc".
+#
+# If the common name is not set correctly, the apiserver will refuse to
+# communicate with the OPA.
+generateAdmissionControllerCerts: true
+admissionControllerCA: ""
+admissionControllerCert: ""
+admissionControllerKey: ""
+
+authz:
+  # Disable if you don't want authorization.
+  # Mostly useful for debugging.
+  enabled: true
+
+# Docker image and tag to deploy.
+image: openpolicyagent/opa
+imageTag: 0.15.1
+imagePullPolicy: IfNotPresent
+
+# Port to which the opa pod will bind itself
+# NOTE IF you use a different port make sure it maches the ones in the readinessProbe
+# and livenessProbe
+port: 443
+
+mgmt:
+  enabled: true
+  image: openpolicyagent/kube-mgmt
+  imageTag: "0.10"
+  imagePullPolicy: IfNotPresent
+  extraArgs: []
+  resources: {}
+  data:
+    enabled: false
+  configmapPolicies:
+# NOTE IF you use these, remember to update the RBAC rules below to allow
+#      permissions to get, list, watch, patch and update configmaps
+    enabled: false
+    namespaces: [opa, kube-federation-scheduling-policy]
+    requireLabel: true
+  replicate:
+# NOTE IF you use these, remember to update the RBAC rules below to allow
+#      permissions to replicate these things
+    cluster: []
+#     - [group/]version/resource
+    namespace: []
+#     - [group/]version/resource
+    path: kubernetes
+
+# Log level for OPA ('debug', 'info', 'error') (app default=info)
+logLevel: info
+
+# Log format for OPA ('text', 'json') (app default=text)
+logFormat: text
+
+# Number of OPA replicas to deploy. OPA maintains an eventually consistent
+# cache of policies and data. If you want high availability you can deploy two
+# or more replicas.
+replicas: 1
+
+# To control how the OPA is scheduled on the cluster, set the affinity,
+# tolerations and nodeSelector values below. For example, to deploy OPA onto
+# the master nodes, 1 replica per node:
+#
+# affinity:
+#   podAntiAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#     - labelSelector:
+#         matchExpressions:
+#         - key: "app"
+#           operator: In
+#           values:
+#           - opa
+#       topologyKey: "kubernetes.io/hostname"
+# tolerations:
+# - key: "node-role.kubernetes.io/master"
+#   effect: NoSchedule
+#   operator: Exists
+# nodeSelector:
+#   kubernetes.io/role: "master"
+affinity: {}
+tolerations: []
+nodeSelector: {}
+
+# To control the CPU and memory resource limits and requests for OPA, set the
+# field below.
+resources: {}
+
+rbac:
+  # If true, create & use RBAC resources
+  #
+  create: true
+  rules:
+    cluster: []
+    # - apiGroups:
+    #     - ""
+    #   resources:
+    #   - namespaces
+    #   verbs:
+    #   - get
+    #   - list
+    #   - watch
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+# This proxy allows opa to make Kubernetes SubjectAccessReview checks against the
+# Kubernetes API. You can get a rego function at github.com/open-policy-agent/library
+sar:
+  enabled: false
+  image: lachlanevenson/k8s-kubectl
+  imageTag: latest
+  imagePullPolicy: IfNotPresent
+  resources: {}
+
+# To control the liveness and readiness probes change the fields below.
+readinessProbe:
+  httpGet:
+    path: /health
+    scheme: HTTPS
+    port: 443
+  initialDelaySeconds: 3
+  periodSeconds: 5
+livenessProbe:
+  httpGet:
+    path: /health
+    scheme: HTTPS
+    port: 443
+  initialDelaySeconds: 3
+  periodSeconds: 5
+
+# Set a priorityClass using priorityClassName
+# priorityClassName:
+
+# Timeout for a webhook call in seconds.
+# Starting in kubernetes 1.14 you can set the timeout and it is
+# encouraged to use a small timeout for webhooks. If the webhook call times out, the request
+# the request is handled according to the webhook'sfailure policy.
+# timeoutSeconds: 20
+
+securityContext:
+  enabled: false
+  runAsNonRoot: true
+  runAsUser: 1
+
+deploymentStrategy: {}
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+  # type: RollingUpdate
+
+extraContainers: []
+## Additional containers to be added to the opa pod.
+# - name: example-app
+#   image: example/example-app:latest
+#   args:
+#     - "run"
+#     - "--port=11811"
+#     - "--config=/etc/example-app-conf/config.yaml"
+#     - "--opa-endpoint=https://localhost:443"
+#   ports:
+#     - name: http
+#       containerPort: 11811
+#       protocol: TCP
+#   volumeMounts:
+#     - name: example-app-auth-config
+#       mountPath: /etc/example-app-conf
+
+extraVolumes: []
+## Additional volumes to the opa pod.
+# - name: example-app-auth-config
+#   secret:
+#     secretName: example-app-auth-config
+
+extraPorts: []
+## Additional ports to the opa services. Useful to expose extra container ports.
+# - port: 11811
+#   protocol: TCP
+#   name: http
+#   targetPort: http


### PR DESCRIPTION
Hello OPA team!

As you know, the official helm chart repository is now deprecated, and vendors have to find a place where to publish and distribute their helm charts. 

This is the reason why we post here: https://github.com/helm/charts/pull/8915#issuecomment-728050130 to help your team hosting the OPA helm chart in another location. Thanks to @tsandall, he created a team granting access to this repository.

## TL;DR
```bash
$ helm repo add open-policy-agent https://open-policy-agent.github.io/kube-mgmt/charts
$ helm repo update
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "open-policy-agent" chart repository
Update Complete. ⎈Happy Helming!⎈
$ helm search repo opa
NAME                    CHART VERSION   APP VERSION     DESCRIPTION                                       
open-policy-agent/opa   1.14.6          0.15.1          Open source, general-purpose policy engine. Enf...
```

What we did in this PR was to:

- Create the same chart structure you are currently using in the `gatekeeper` repository.
  - Copy the OPA Helm Chart code from `github.com/helm/charts/stable` to the new location in this repo.
  - Remove the deprecation notes.
- Copy and adapt the CI of the `gatekeeper` repository (GitHub actions) to publish the chart under GitHub Pages.
  - We ignore everything from `gatekeeper` CI but the release of the Helm Chart.
- Configure the repository to use the `gh-pages` branch as the source of GitHub pages.

As you can see, everything is "working," but for sure, it can be improved:

- Be consistent in the CI (Travis or GitHub actions)
- Include missing steps in the GitHub actions CI
- Update the values of the Helm Chart with the newest versions
- E2E tests of the helm chart
- ...

I wanted to keep this PR as small as possible. (Enough to migrate the helm chart).
Feedback is welcomed!