### PR TITLE
Update ClusterRoleBinding apiVersion

### DIFF
--- a/charts/opa/Chart.yaml
+++ b/charts/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.14.6
+version: 1.14.7
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/charts/opa/templates/mgmt-clusterrolebinding.yaml
+++ b/charts/opa/templates/mgmt-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if (and .Values.rbac.create .Values.mgmt.enabled) -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:


### PR DESCRIPTION
Currently `helm lint` fails with the error

```
helm lint .
==> Linting .
[ERROR] templates/mgmt-clusterrolebinding.yaml: the kind "rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding" is deprecated in favor of "rbac.authorization.k8s.io/v1 ClusterRoleBinding"

Error: 1 chart(s) linted, 1 chart(s) failed
```

Hence updating the CRB apiVersion to `rbac.authorization.k8s.io/v1`