### PR TITLE
Provide a list of alternate DNS names for the genSignedCert function

### DIFF
--- a/charts/opa/templates/webhookconfiguration.yaml
+++ b/charts/opa/templates/webhookconfiguration.yaml
@@ -1,6 +1,6 @@
 {{- $cn := printf "%s.%s.svc" ( include "opa.fullname" . ) .Release.Namespace }}
 {{- $ca := genCA "opa-admission-ca" 3650 -}}
-{{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+{{- $cert := genSignedCert $cn nil (list $cn) 3650 $ca -}}
 kind: {{ .Values.admissionControllerKind }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 metadata:


### PR DESCRIPTION
Small fix for the issue in k8s 1.19+
> x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0

Issue related to new Go version: https://v1-19.docs.kubernetes.io/docs/setup/release/notes/
> The deprecated, legacy behavior of treating the CommonName field on X.509 serving certificates as a host name when no Subject Alternative Names are present is now disabled by default. It can be temporarily re-enabled by adding the value x509ignoreCN=0 to the GODEBUG environment variable. (#93264, @justaugustus) [SIG API Machinery, Auth, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation, Network, Node, Release, Scalability, Storage and Testing]

Before:
![image](https://user-images.githubusercontent.com/892060/109295699-235b8900-786a-11eb-85dd-61bf9f22aa42.png)

After:
![image](https://user-images.githubusercontent.com/892060/109295717-2a829700-786a-11eb-9c86-3973b2a4f392.png)
