### PR TITLE
allow custom label openpolicyagent.org/policy=rego

### DIFF
--- a/cmd/kube-mgmt/flag_test.go
+++ b/cmd/kube-mgmt/flag_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/open-policy-agent/kube-mgmt/pkg/configmap"
+	"github.com/spf13/cobra"
 )
 
 func TestFlagParsing(t *testing.T) {
@@ -48,5 +52,73 @@ func TestFlagString(t *testing.T) {
 
 	if err := f.Set("example.org/foo/bar"); err != nil || f.String() != expected {
 		t.Fatalf("Exepcted %v but got: %v (err: %v)", expected, f.String(), err)
+	}
+}
+
+func TestPolicyFlags(t *testing.T) {
+	tt := []struct {
+		name           string
+		flag           string
+		value          string
+		expectFullFlag string
+		err            error
+	}{
+		{
+			name:           "valid",
+			flag:           "openpolicyagent.org/policy",
+			value:          "rego",
+			expectFullFlag: "openpolicyagent.org/policy=rego",
+			err:            nil,
+		},
+		{
+			name:           "invalidFlag",
+			flag:           "-foo",
+			value:          "rego",
+			expectFullFlag: "",
+			err:            errors.New(`invalid label key "-foo": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`),
+		},
+		{
+			name:           "invalidValue",
+			flag:           "foo",
+			value:          "-rego",
+			expectFullFlag: "",
+			err:            errors.New(`invalid label value: "-rego": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')`),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			rootCmd := &cobra.Command{
+				Use:   "test",
+				Short: "test",
+				RunE: func(cmd *cobra.Command, args []string) error {
+					return nil
+				},
+			}
+
+			var params params
+			rootCmd.Flags().StringVarP(&params.policyLabel, "policy-label", "", "", "replace label openpolicyagent.org/policy")
+			rootCmd.Flags().StringVarP(&params.policyValue, "policy-value", "", "", "replace value rego")
+
+			rootCmd.SetArgs([]string{"--policy-label=" + tc.flag, "--policy-value=" + tc.value})
+			rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+				if rootCmd.Flag("policy-label").Value.String() != "" || rootCmd.Flag("policy-value").Value.String() != "" {
+					f, err := configmap.CustomPolicyLabel(params.policyLabel, params.policyValue)
+					if err != nil {
+						if tc.err.Error() != err.Error() {
+							t.Errorf("exp: %v\ngot: %v\n", tc.err.Error(), err.Error())
+							t.FailNow()
+						}
+					}
+
+					if tc.expectFullFlag != f {
+						t.Errorf("expected: flag:%v got: %v", tc.expectFullFlag, f)
+						t.FailNow()
+					}
+				}
+				return nil
+			}
+			rootCmd.Execute()
+		})
 	}
 }

--- a/cmd/kube-mgmt/main.go
+++ b/cmd/kube-mgmt/main.go
@@ -75,8 +75,8 @@ func main() {
 	rootCmd.Flags().BoolVarP(&params.opaAllowInsecure, "opa-allow-insecure", "", false, "allow insecure https connections to OPA")
 	rootCmd.Flags().StringVarP(&params.podName, "pod-name", "", "", "set pod name (required for admission registration ownership)")
 	rootCmd.Flags().StringVarP(&params.podNamespace, "pod-namespace", "", "", "set pod namespace (required for admission registration ownership)")
-	rootCmd.Flags().StringVarP(&params.policyLabel, "policy-label", "", "", "replace label openpolicyagent.org/policy")
-	rootCmd.Flags().StringVarP(&params.policyValue, "policy-value", "", "", "replace value rego")
+	rootCmd.Flags().StringVarP(&params.policyLabel, "policy-label", "", "openpolicyagent.org/policy", "replace label openpolicyagent.org/policy")
+	rootCmd.Flags().StringVarP(&params.policyValue, "policy-value", "", "rego", "replace value rego")
 
 	// Replication options.
 	rootCmd.Flags().BoolVarP(&params.enablePolicies, "enable-policies", "", true, "whether to automatically discover policies from ConfigMaps")
@@ -162,6 +162,8 @@ func run(params *params) {
 				params.requirePolicyLabel,
 				params.enablePolicies,
 				params.enableData,
+				params.policyLabel,
+				params.policyValue,
 			),
 		)
 		_, err = sync.Run(params.policies)

--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -41,12 +41,6 @@ const (
 	syncResetBackoffMax = time.Second * 30
 )
 
-var (
-	// policyLabelKey can be replaced by --custom-label option
-	policyLabelKey   = "openpolicyagent.org/policy"
-	policyLabelValue = "rego"
-)
-
 // CustomPolicyLabel allows the default key "openpolicyagent.org/policy"
 // to be replaced by another value. This would allow two instances of kube-mgmt
 // to share a single namepace with config maps for different servers. (ie. validating & mutating)
@@ -56,8 +50,8 @@ func CustomPolicyLabel(key, value string) (string, error) {
 		return "", err
 	}
 
-	policyLabelKey = key
-	policyLabelValue = value
+	policyLabelKey := key
+	policyLabelValue := value
 	fullLabel := strings.Join([]string{policyLabelKey, policyLabelValue}, "=")
 	return fullLabel, nil
 }
@@ -66,7 +60,7 @@ func CustomPolicyLabel(key, value string) (string, error) {
 // specified namespaces and/or with a policy or data label. The first bool return
 // value specifies a policy/data match and the second bool indicates if the configmap
 // contains a policy.
-func DefaultConfigMapMatcher(namespaces []string, requirePolicyLabel, enablePolicies, enableData bool) func(*v1.ConfigMap) (bool, bool) {
+func DefaultConfigMapMatcher(namespaces []string, requirePolicyLabel, enablePolicies, enableData bool, policyLabelKey, policyLabelValue string) func(*v1.ConfigMap) (bool, bool) {
 	return func(cm *v1.ConfigMap) (bool, bool) {
 		var match, isPolicy bool
 


### PR DESCRIPTION
--policy-label=my.org/policy
--policy-value=mutating

I would like two run separate OPA servers using the same policy namespace. Currently openpolicyagent.org/policy=rego" is hard coded.