### PR TITLE
Preparing v0.12.1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BIN := kube-mgmt
 PKG := github.com/open-policy-agent/kube-mgmt
 REGISTRY ?= openpolicyagent
-VERSION := 0.13
+VERSION := 0.12.1
 ARCH := amd64
 COMMIT := $(shell ./build/get-build-commit.sh)
 

--- a/charts/opa/values.yaml
+++ b/charts/opa/values.yaml
@@ -123,7 +123,7 @@ extraArgs: []
 mgmt:
   enabled: true
   image: openpolicyagent/kube-mgmt
-  imageTag: "0.10"
+  imageTag: "0.12.1"
   imagePullPolicy: IfNotPresent
 # NOTE insecure http port conjointly used for mgmt access and prometheus metrics export
   port: 8181

--- a/examples/service_validation/admission_controller.yaml
+++ b/examples/service_validation/admission_controller.yaml
@@ -59,7 +59,7 @@ spec:
               mountPath: /certs
               name: opa-server
         - name: kube-mgmt
-          image: openpolicyagent/kube-mgmt:0.12
+          image: openpolicyagent/kube-mgmt:0.12.1
       volumes:
         - name: opa-server
           secret:

--- a/manifests/deployment.yml
+++ b/manifests/deployment.yml
@@ -64,4 +64,4 @@ spec:
         - name: http
           containerPort: 8181
       - name: kube-mgmt
-        image: openpolicyagent/kube-mgmt:0.12
+        image: openpolicyagent/kube-mgmt:0.12.1


### PR DESCRIPTION
AFAICT there is no automation for release notes, right?

I had to rollback the `VERSION` variable in the `Makefile` because it's used to build the image from the github action.

If this is fine I can merge it, tag it and add the description manually. Let me know. :shipit: 