### PR TITLE
Introducing bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,18 @@
+[bumpversion]
+commit = True
+tag = True
+current_version = 0.12.1
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<rc>\d+))?
+serialize = 
+	{major}.{minor}.{patch}-rc{rc}
+	{major}.{minor}.{patch}
+
+[bumpversion:file:Makefile]
+
+[bumpversion:file:charts/opa/values.yaml]
+
+[bumpversion:file:examples/service_validation/admission_controller.yaml]
+
+[bumpversion:file:charts/opa/Chart.yaml]
+
+[bumpversion:file:manifests/deployment.yml]


### PR DESCRIPTION
In order to smooth the release process, I introduced [bumpversion](https://pypi.org/project/bumpversion/).

Bumpversion will take care of bumping the version in all the needed files, commit the changes and tag them accordingly to semver. We'll still need to create the release and write the release notes by hand, but at least we can be sure releases will update all the needed files.