### PR TITLE
Fix the name of ingress-bad.yaml in NOTES.txt

### DIFF
--- a/charts/opa/templates/NOTES.txt
+++ b/charts/opa/templates/NOTES.txt
@@ -33,7 +33,7 @@ cat > ingress-bad.yaml <<EOF
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: ingress-ok
+  name: ingress-bad
 spec:
   rules:
   - host: signin.acmecorp.com


### PR DESCRIPTION
The name of `ingress-bad.yaml` in NOTES.txt is `ingress-ok`. This causes confusion and results in the following error in `# 3`.

```bash
$ # 1. Create a namespace called "opa-example"
$ kubectl create namespace opa-example
namespace/opa-example created
$ # 2. Create an Ingress in the "opa-example" namespace that complies with the policy.
$ cat > ingress-ok.yaml <<EOF
> apiVersion: extensions/v1beta1
> kind: Ingress
> metadata:
>   name: ingress-ok
> spec:
>   rules:
>   - host: signin.dev.acmecorp.com
>     http:
>       paths:
>       - backend:
>           serviceName: nginx
>           servicePort: 80
> EOF
$ kubectl -n opa-example create -f ingress-ok.yaml
Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
ingress.extensions/ingress-ok created
$ # 3. Try to create an Ingress in the "opa-example" namespace that violates the policy.
$ cat > ingress-bad.yaml <<EOF
> apiVersion: extensions/v1beta1
> kind: Ingress
> metadata:
>   name: ingress-ok
> spec:
>   rules:
>   - host: signin.acmecorp.com
>     http:
>       paths:
>       - backend:
>           serviceName: nginx
>           servicePort: 80
> EOF
$ kubectl -n opa-example create -f ingress-bad.yaml
Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
Error from server (AlreadyExists): error when creating "ingress-bad.yaml": ingresses.extensions "ingress-ok" already exists

```

This error is caused by the fact that `ingress-ok` is used in both `ingress-ok.yaml` and `ingress-bad.yaml`.
So, I fixed it.