### PR TITLE
Add environment variables to OPA container

### DIFF
--- a/charts/opa/README.md
+++ b/charts/opa/README.md
@@ -88,6 +88,7 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `opa` | OPA configuration. | See [values.yaml](values.yaml) |
 | `mgmt` | kube-mgmt configuration. | See [values.yaml](values.yaml) |
 | `mgmt.port` | kube-mgmt/prometheus port used to communicate with opa. | See [values.yaml](values.yaml) |
+| `mgmt.extraEnv` | Additional environment variables to be added to the kube-mgmt container | `[]` |
 | `sar.resources` | CPU and memory limits for the sar container. | `{}` |
 | `priorityClassName` | The name of the priorityClass for the pods. | Unset |
 | `prometheus.enabled` | Flag to expose the `/metrics` endpoint to be scraped. | `false` |
@@ -100,6 +101,7 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `securityContext` | Security context for the containers | `{enabled: false, runAsNonRoot: true, runAsUser: 1}` |
 | `deploymentStrategy` | Specify deployment spec rollout strategy | `{}` |
 | `extraArgs` | Additional arguments to be added to the opa container | `[]` |
+| `extraEnv` | Additional environment variables to be added to the opa container | `[]` |
 | `extraContainers` | Additional containers to be added to the deployment | `[]` |
 | `extraVolumes` | Additional volumes to be added to the deployment | `[]` |
 | `extraPorts` | Additional ports to OPA service. Useful to expose `extraContainer` ports. | `[]` |

--- a/charts/opa/templates/deployment.yaml
+++ b/charts/opa/templates/deployment.yaml
@@ -92,6 +92,10 @@ spec:
 {{- end }}
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          env:
+{{- if .Values.extraEnv }}        
+{{ toYaml .Values.extraEnv | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           args:
@@ -153,6 +157,10 @@ spec:
         - name: mgmt
           image: {{ .Values.mgmt.image }}:{{ coalesce .Values.mgmt.imageTag .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.mgmt.imagePullPolicy }}
+          env:
+{{- if .Values.mgmt.extraEnv }}        
+{{ toYaml .Values.mgmt.extraEnv | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.mgmt.resources | indent 12 }}
           args:

--- a/charts/opa/values.yaml
+++ b/charts/opa/values.yaml
@@ -125,6 +125,9 @@ port: 443
 
 extraArgs: []
 
+# Extra environment variables to be loaded into the OPA container
+extraEnv: []
+
 mgmt:
   enabled: false
   image: openpolicyagent/kube-mgmt
@@ -133,6 +136,7 @@ mgmt:
 # NOTE insecure http port conjointly used for mgmt access and prometheus metrics export
   port: 8181
   extraArgs: []
+  extraEnv: []
   resources: {}
   data:
     enabled: false


### PR DESCRIPTION
This would allow users to specify environment variables that would be added to the OPA container, so that they could be picked up in Rego scripts ex. for making API calls using authentication.