### PR TITLE
Make cert-manager certs duration configurable

### DIFF
--- a/charts/opa/README.md
+++ b/charts/opa/README.md
@@ -60,6 +60,8 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `certManager.enabled` | Setup the Webhook using cert-manager | `false` |
+| `certManager.rootCACertificateDuration` | Duration of the Webhook's root CA | `43800h` (5y) |
+| `certManager.servingCertificateDuration` | Duration of the Webhook's serving certificate | `8760h` (1y) |
 | `admissionController.enabled` | | `true` |
 | `admissionController.kind` | Type of admission controller to install. | `ValidatingWebhookConfiguration` |
 | `admissionController.failurePolicy` | Fail-open (`Ignore`) or fail-closed (`Fail`)? | `Ignore` |

--- a/charts/opa/templates/webhookconfiguration.yaml
+++ b/charts/opa/templates/webhookconfiguration.yaml
@@ -61,7 +61,7 @@ metadata:
 {{ include "opa.labels.standard" . | indent 4 }}
 spec:
   secretName: {{ include "opa.rootCACertificate" . }}
-  duration: 43800h # 5y
+  duration: {{ .Values.certManager.rootCACertificateDuration | quote }}
   issuerRef:
     name: {{ include "opa.selfSignedIssuer" . }}
   commonName: "ca.webhook.opa"
@@ -87,7 +87,7 @@ metadata:
 {{ include "opa.labels.standard" . | indent 4 }}
 spec:
   secretName: {{ template "opa.fullname" . }}-cert
-  duration: 8760h # 1y
+  duration: {{ .Values.certManager.servingCertificateDuration | quote }}
   issuerRef:
     name: {{ include "opa.rootCAIssuer" . }}
   dnsNames:

--- a/charts/opa/values.yaml
+++ b/charts/opa/values.yaml
@@ -17,6 +17,8 @@ opa:
 # Setup the webhook using cert-manager
 certManager:
   enabled: false
+  rootCACertificateDuration: 43800h # 5y
+  servingCertificateDuration: 8760h # 1y
 
 # Expose the prometheus scraping endpoint
 prometheus:


### PR DESCRIPTION
Hardcoded certificate duration when using cert-manager may be insufficient in some cases (compare to using `generateCerts`, which creates certificate with 10 year validity).

In this proposal, the duration of the certificates generated by cert-manager is made configurable. The previously hardcoded values are retained as default values (5y for CA and 1y for serving certificate).