### PR TITLE
Enable setting admissioncontroller annotations

### DIFF
--- a/charts/opa/README.md
+++ b/charts/opa/README.md
@@ -64,6 +64,7 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `certManager.servingCertificateDuration` | Duration of the Webhook's serving certificate | `8760h` (1y) |
 | `admissionController.enabled` | | `true` |
 | `admissionController.kind` | Type of admission controller to install. | `ValidatingWebhookConfiguration` |
+| `admissionController.annotations` | Annotations placed on all admissionController resources (Secret/Certificate/Issuer/AdmissionController). | `[]` |
 | `admissionController.failurePolicy` | Fail-open (`Ignore`) or fail-closed (`Fail`)? | `Ignore` |
 | `admissionController.rules` | Types of operations resources to check. | `*` |
 | `admissionController.namespaceSelector` | Namespace selector for the admission controller | See [values.yaml](values.yaml) |

--- a/charts/opa/templates/webhookconfiguration.yaml
+++ b/charts/opa/templates/webhookconfiguration.yaml
@@ -11,6 +11,9 @@ metadata:
     certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace (include "opa.rootCACertificate" .) | quote }}
     cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace (include "opa.rootCACertificate" .) | quote }}
 {{- end }}
+{{- if .Values.admissionController.annotations }}
+{{ toYaml .Values.admissionController.annotations | indent 4 }}
+{{- end }}
   labels:
 {{ include "opa.labels.standard" . | indent 4 }}
 webhooks:
@@ -46,6 +49,10 @@ webhooks:
 apiVersion: {{ include "opa.certManagerApiVersion" . }}
 kind: Issuer
 metadata:
+{{- if .Values.admissionController.annotations }}
+  annotations:
+{{ toYaml .Values.admissionController.annotations | indent 4 }}
+{{- end }}
   name: {{ include "opa.selfSignedIssuer" . }}
   labels:
 {{ include "opa.labels.standard" . | indent 4 }}
@@ -56,6 +63,10 @@ spec:
 apiVersion: {{ include "opa.certManagerApiVersion" . }}
 kind: Certificate
 metadata:
+{{- if .Values.admissionController.annotations }}
+  annotations:
+{{ toYaml .Values.admissionController.annotations | indent 4 }}
+{{- end }}
   name: {{ include "opa.rootCACertificate" . }}
   labels:
 {{ include "opa.labels.standard" . | indent 4 }}
@@ -71,6 +82,10 @@ spec:
 apiVersion: {{ include "opa.certManagerApiVersion" . }}
 kind: Issuer
 metadata:
+{{- if .Values.admissionController.annotations }}
+  annotations:
+{{ toYaml .Values.admissionController.annotations | indent 4 }}
+{{- end }}
   name: {{ include "opa.rootCAIssuer" . }}
   labels:
 {{ include "opa.labels.standard" . | indent 4 }}
@@ -82,6 +97,10 @@ spec:
 apiVersion: {{ include "opa.certManagerApiVersion" . }}
 kind: Certificate
 metadata:
+{{- if .Values.admissionController.annotations }}
+  annotations:
+{{ toYaml .Values.admissionController.annotations | indent 4 }}
+{{- end }}
   name: {{ include "opa.servingCertificate" . }}
   labels:
 {{ include "opa.labels.standard" . | indent 4 }}
@@ -98,6 +117,10 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
+{{- if .Values.admissionController.annotations }}
+  annotations:
+{{ toYaml .Values.admissionController.annotations | indent 4 }}
+{{- end }}
   name: {{ template "opa.fullname" . }}-cert
   labels:
     app: {{ template "opa.fullname" . }}

--- a/charts/opa/values.yaml
+++ b/charts/opa/values.yaml
@@ -57,6 +57,10 @@ admissionController:
   # To enforce mutating policies, change to MutatingWebhookConfiguration.
   kind: ValidatingWebhookConfiguration
 
+  # To set annotations on all admissionController resources (Secret/Certificate/Issuer/AdmissionController)
+  # annotations:
+  #   example: value
+
   # To _fail closed_ on failures, change to Fail. During initial testing, we
   # recommend leaving the failure policy as Ignore.
   failurePolicy: Ignore


### PR DESCRIPTION
Enable setting annotations on admissioncontroller resources. This, for instance, allows for ArgoCD PreSync hooks to be used to guarantee the correct syncing order.