### PR TITLE
Add support for v1 admissionReviewVersions

### DIFF
--- a/charts/opa/templates/webhookconfiguration.yaml
+++ b/charts/opa/templates/webhookconfiguration.yaml
@@ -18,7 +18,7 @@ metadata:
 {{ include "opa.labels.standard" . | indent 4 }}
 webhooks:
   - name: webhook.openpolicyagent.org
-    admissionReviewVersions: ["v1beta1"]
+    admissionReviewVersions: ["v1", "v1beta1"]
 {{- with .Values.admissionController.namespaceSelector }}
     namespaceSelector:
 {{ toYaml . | indent 6 }}


### PR DESCRIPTION
The Webhook Configuration should support both "v1beta1" as well as "v1" of AdmissionReviews.
https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#configure-admission-webhooks-on-the-fly

Otherwise the following error occurs (on a v1.21 cluster):
> Internal error occurred: failed calling webhook "webhook.openpolicyagent.org": converting (v1.AdmissionReview) to (v1beta1.AdmissionReview): unknown conversion