### PR TITLE
[charts] fix conditional around deployment annotations.

### DIFF
--- a/charts/opa/templates/deployment.yaml
+++ b/charts/opa/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
   {{- end }}
   template:
     metadata:
-{{- if or .Values.generateCerts .Values.opa }}
+{{- if or .Values.generateCerts .Values.opa .Values.annotations }}
       annotations:
 {{- if .Values.generateCerts }}
         checksum/certs: {{ include (print $.Template.BasePath "/webhookconfiguration.yaml") . | sha256sum }}


### PR DESCRIPTION
The conditional on the annotations does not consider annotations users may have passed via the values, when opa is false and generateCerts is false the template as it was leads to broken Deployment manifest.

This patch ensures that `opa` and `generateCerts` can be false and not break the generated Deployment.