### PR TITLE
make rbac rules configurable for replication

### DIFF
--- a/charts/opa-kube-mgmt/templates/rbac-mgmt.yaml
+++ b/charts/opa-kube-mgmt/templates/rbac-mgmt.yaml
@@ -10,12 +10,7 @@ metadata:
     component: mgmt
   name: {{ template "opa.mgmtfullname" . }}
 rules:
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["*"]
-  - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["get", "list", "watch"]
+{{ toYaml .Values.rbac.rules.cluster | indent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/opa-kube-mgmt/values.yaml
+++ b/charts/opa-kube-mgmt/values.yaml
@@ -201,6 +201,14 @@ resources: {}
 rbac:
   # If true, create RBAC resources
   create: true
+  rules:
+    cluster:
+    - apiGroups: [""]
+      resources: ["configmaps"]
+      verbs: ["*"]
+    - apiGroups: [""]
+      resources: ["namespaces"]
+      verbs: ["get", "list", "watch"]
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
- This PR undoes parts of [fix: simplify rbac creation #108](https://github.com/open-policy-agent/kube-mgmt/pull/108)
- This is required if a user is using replication as the pod may need access to other resources depending on the policies being enforced