### PR TITLE
Fix indentation of OPA extraArgs in deployment.yaml

### DIFF
--- a/charts/opa-kube-mgmt/templates/deployment.yaml
+++ b/charts/opa-kube-mgmt/templates/deployment.yaml
@@ -122,7 +122,7 @@ spec:
             - "/bootstrap"
             {{- end }}
             {{- range .Values.extraArgs }}
-             - {{ . }}
+            - {{ . }}
             {{- end }}
           volumeMounts:
             {{- if .Values.useHttps }}


### PR DESCRIPTION
Hello,
thanks for keeping up the good work in this repo!

I wanted to upgrade to the latest 7.0.0 release, but came across this minor issue in Helm output:
```
 Error: YAML parse error on opa-kube-mgmt/templates/deployment.yaml:
error converting YAML to JSON: yaml: line 45: did not find expected '-' indicator
```

This is due to minor indentation misalignment - yay YAML!