### PR TITLE
Fix vulnerabilities found in the Alpine Base image

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,7 +6,7 @@ build:
   artifacts:
     - image: openpolicyagent/kube-mgmt
       ko:
-        fromImage: alpine:3.12.3
+        fromImage: alpine:3.12.12
         main: ./cmd/kube-mgmt/.../
         ldflags:
           - "-X github.com/open-policy-agent/kube-mgmt/pkg/version.Version={{.VERSION}}"


### PR DESCRIPTION
Update the base image to 3.12.12 to fix the following CVE's:
- CVE-2021-28831
- CVE-2021-30139
- CVE-2021-36159
- CVE-2021-42375
- CVE-2021-423{78-86}
- CVE-2018-25032
- CVE-2022-28391

Fixes #164