### PR TITLE
Update docs after latest changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ bin
 .go
 *.tgz
 tags.json
-
+.idea


### PR DESCRIPTION
There were few recent changes that might be considered breaking changes like https://github.com/open-policy-agent/kube-mgmt/pull/151 or https://github.com/open-policy-agent/kube-mgmt/pull/163 where for example `--polices` was renamed into `--namespace` or statusAnnotationKey value from `openpolicyagent.org/policy-status` to `openpolicyagent.org/kube-mgmt-status`

This PR updates the docs so that they reflect the latest changes.

Signed-off-by: Adrian Aneci <aneci.adrian@gmail.com>