### PR TITLE
correct indent

### DIFF
--- a/charts/opa-kube-mgmt/templates/deployment.yaml
+++ b/charts/opa-kube-mgmt/templates/deployment.yaml
@@ -163,7 +163,7 @@ spec:
 {{ toYaml .Values.mgmt.extraEnv | indent 12 }}
 {{- end }}
           resources:
-            {{ toYaml .Values.mgmt.resources | indent 12 }}
+            {{ toYaml .Values.mgmt.resources | nindent 12 }}
           args:
             {{- if .Values.authz.enabled }}
             - --opa-auth-token-file=/bootstrap/mgmt-token


### PR DESCRIPTION
resolve https://github.com/open-policy-agent/kube-mgmt/issues/168

Actually with the chart release (7.0.6) when you try to set some specific resource limits to the kube-mgmt deployment like for exemple.


    mgmt:
      limits:
        cpu: 0.5
        memory: 128Mi
      requests:
        cpu: 0.1
        memory: 64Mi
       
The release will fail because of the render of the deployment.yaml
For fix it we need to give the correct indent to the added ressource.

Signed-off-by: Remy Genisson <genisson.remy@gmail.com>