### PR TITLE
Update the base image to Alpine to 3.16.2

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,7 +6,7 @@ build:
   artifacts:
     - image: openpolicyagent/kube-mgmt
       ko:
-        fromImage: alpine:3.12.12
+        fromImage: alpine:3.16.2
         main: ./cmd/kube-mgmt/.../
         ldflags:
           - "-X github.com/open-policy-agent/kube-mgmt/pkg/version.Version={{.VERSION}}"


### PR DESCRIPTION
The 3.12.x line is out of support. Move to the latest version to get back on a supported version. This also addresses CVE-2022-37434.