### PR TITLE
workflow: update set-output usage

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: release version
         id: theVersion
-        run: echo "::set-output name=theVersion::$(echo ${GITHUB_REF##*/})"
+        run: echo "theVersion=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
       - uses: volesen/setup-skaffold@v1.1
         with:
           version: v1.38.0


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
