### PR TITLE
Implemented optional use of existing secret for mgmt token

### DIFF
--- a/charts/opa-kube-mgmt/templates/deployment.yaml
+++ b/charts/opa-kube-mgmt/templates/deployment.yaml
@@ -50,7 +50,11 @@ spec:
           - -c
           - |
 {{- if .Values.authz.enabled }}
+{{- if .Values.authz.mgmtToken}}
+            cat /mgmt-token-secret/mgmt-token > /bootstrap/mgmt-token
+{{- else }}
             tr -dc 'A-F0-9' < /dev/urandom | dd bs=1 count=32 2>/dev/null > /bootstrap/mgmt-token
+{{- end }}
             TOKEN=`cat /bootstrap/mgmt-token`
             cat > /bootstrap/authz.rego <<EOF
             package system.authz
@@ -75,6 +79,11 @@ spec:
           volumeMounts:
             - name: bootstrap
               mountPath: /bootstrap
+{{- if .Values.authz.mgmtToken}}
+            - name: mgmt-token-secret
+              mountPath: /mgmt-token-secret
+              readOnly: true
+{{- end }}
 {{- end }}
 {{- if .Values.hostNetwork.enabled }}
       hostNetwork: true
@@ -227,6 +236,14 @@ spec:
 {{- if or .Values.authz.enabled .Values.bootstrapPolicies}}
         - name: bootstrap
           emptyDir: {}
+{{- if .Values.authz.mgmtToken}}
+        - name: mgmt-token-secret
+          secret:
+            secretName: {{.Values.authz.mgmtToken.secretName}}
+            items:
+              - key: {{ .Values.authz.mgmtToken.secretKey | default "mgmtToken" }}
+                path: mgmt-token
+{{- end }}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8}}
 {{- end }}

--- a/charts/opa-kube-mgmt/templates/mgmt-token-secret.yaml
+++ b/charts/opa-kube-mgmt/templates/mgmt-token-secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.e2eMgmtTokenSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mgmt-token-secret
+type: Opaque
+stringData:
+  mgmtToken: mgmt-token-secret-value
+{{- end -}}

--- a/charts/opa-kube-mgmt/values.yaml
+++ b/charts/opa-kube-mgmt/values.yaml
@@ -110,6 +110,10 @@ authz:
   # Disable if you don't want authorization.
   # Mostly useful for debugging.
   enabled: true
+  # Used for setting the mgmt token used for authz instead of auto generated default
+  # mgmtToken:
+  #    secretName: name of the secret
+  #    secretKey: (optional) key from the secret - default value is: "mgmtToken"
 
 # Use hostNetwork setting on OPA pod
 hostNetwork:

--- a/test/e2e/custom_mgmt_token/test.sh
+++ b/test/e2e/custom_mgmt_token/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+set -x
+
+TOKEN="mgmt-token-secret-value"
+OPA="http --ignore-stdin --default-scheme=https --verify=no -A bearer -a ${TOKEN} :8443/v1"
+
+${OPA}/data | jq -e '.result.test_helm_kubernetes_quickstart|keys|length==3'
+
+kubectl apply -f "$(dirname $0)/../fixture.yaml"
+
+${OPA}/policies | jq -e '.result|any(.id=="default/policy-include/include.rego")==true'
+${OPA}/data/example/include/allow | jq -e '.result==true'
+
+${OPA}/data/default | jq -e '.result|keys==["data-include"]'
+${OPA}/data/default/data-include | jq -e '.result["include.json"].inKey=="inValue"'
+
+kubectl get cm -l openpolicyagent.org/policy=rego -ojson | \
+  jq -e '.items[].metadata.annotations["openpolicyagent.org/kube-mgmt-status"]|fromjson|.status=="ok"'
+
+kubectl get cm -l openpolicyagent.org/data=opa -ojson | \
+  jq -e '.items[].metadata.annotations["openpolicyagent.org/kube-mgmt-status"]|fromjson|.status=="ok"'

--- a/test/e2e/custom_mgmt_token/values.yaml
+++ b/test/e2e/custom_mgmt_token/values.yaml
@@ -1,0 +1,7 @@
+e2eMgmtTokenSecret: true
+opa:
+  replicas: 2
+authz:
+  enabled: true
+  mgmtToken:
+    secretName: mgmt-token-secret

--- a/test/linter/test.sh
+++ b/test/linter/test.sh
@@ -45,6 +45,11 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+helm lint charts/opa-kube-mgmt --strict --set authz.enabled=true --set authz.mgmtToken.secretName=secretName --set authz.mgmtToken.secretKey=secretKey
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
 echo "=================================================================================="
 echo "                                LINT PASSED"
 echo "=================================================================================="


### PR DESCRIPTION
This PR adds an optional functionality to mount and use existing secret as mgmt-token for the helm chart, instead of generating a new one. This is useful when specifying more than 1 replica and we want them to use the same token.