### PR TITLE
Added extraVolumeMounts for mounting extraVolumes into OPA pod

### DIFF
--- a/charts/opa-kube-mgmt/templates/deployment.yaml
+++ b/charts/opa-kube-mgmt/templates/deployment.yaml
@@ -149,6 +149,9 @@ spec:
               readOnly: true
               mountPath: /bootstrap
 {{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12}}
+{{- end }}
           readinessProbe:
             httpGet:
               path: /health

--- a/charts/opa-kube-mgmt/values.yaml
+++ b/charts/opa-kube-mgmt/values.yaml
@@ -271,6 +271,11 @@ extraVolumes: []
 #   secret:
 #     secretName: example-app-auth-config
 
+extraVolumeMounts: []
+## Mounting config for using the additional volumes
+#  - name: example-app-auth-config
+#    mountPath: /mount/path
+
 extraPorts: []
 ## Additional ports to the opa services. Useful to expose extra container ports.
 # - port: 11811

--- a/test/linter/test.sh
+++ b/test/linter/test.sh
@@ -50,6 +50,11 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+helm lint charts/opa-kube-mgmt --strict --set extraVolumeMounts\[0\].name=storage --set extraVolumeMounts\[0\].mountPath=/storage
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
 echo "=================================================================================="
 echo "                                LINT PASSED"
 echo "=================================================================================="


### PR DESCRIPTION
Currently we have ability to specify `extraVolumes` values.yaml:  https://github.com/open-policy-agent/kube-mgmt/blob/master/charts/opa-kube-mgmt/values.yaml#L268, however it is not possible to mount and use them in the OPA pod. This PR adds the volumeMounts that can be used to mount them. 