### PR TITLE
change to sharedInformer

### DIFF
--- a/pkg/data/generic.go
+++ b/pkg/data/generic.go
@@ -287,13 +287,8 @@ func (s *GenericSync) syncAll(objs []interface{}) error {
 	if err != nil {
 		return err
 	}
-
-	err = s.opa.PutData("/", payload)
-
-	if err != nil {
-		logrus.Errorf("%s", err)
-	}
-	return err
+	
+	return s.opa.PutData("/", payload)
 }
 
 func generateSyncPayload(objs []interface{}, namespaced bool) (map[string]interface{}, error) {


### PR DESCRIPTION
https://github.com/open-policy-agent/kube-mgmt/issues/142

im still not sure whats happening here, but client-go says this 
```
// NewInformer returns a Store and a controller for populating the store
// while also providing event notifications. You should only used the returned
// Store for Get/List operations; Add/Modify/Deletes will cause the event
// notifications to be faulty.
```

