### PR TITLE
helm chart: fix the upgrade of the PodDisruptionBudget's apiVersion

### DIFF
--- a/charts/opa-kube-mgmt/templates/poddisruptionbudget.yaml
+++ b/charts/opa-kube-mgmt/templates/poddisruptionbudget.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodDisruptionBudget" }}
-apiVersion: policy/v1beta1
-{{- else }}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
Previously the chart used the deprecated apiVersion policy/v1beta1 as long as it was avaiable in the cluster. This is against the recommendation of upgrading the release to a supported apiVersion prior to upgrading the cluster to a version that removes the deprecated apiVersion: <https://helm.sh/docs/topics/kubernetes_apis/#helm-users>

Closes #184