### PR TITLE
add a way to ignore namespaces

### DIFF
--- a/cmd/kube-mgmt/main.go
+++ b/cmd/kube-mgmt/main.go
@@ -95,7 +95,7 @@ func main() {
 	rootCmd.Flags().VarP(&params.replicateNamespace, "replicate", "", "replicate namespace-level resources")
 	rootCmd.Flags().VarP(&params.replicateCluster, "replicate-cluster", "", "replicate cluster-level resources")
 	rootCmd.Flags().StringVarP(&params.replicatePath, "replicate-path", "", "kubernetes", "set path to replicate data into")
-	rootCmd.Flags().StringSliceVarP(&params.replicateIgnoreNs, "ignore-namespaces", "", []string{"opa"}, "namespaces that are ignored by replication")
+	rootCmd.Flags().StringSliceVarP(&params.replicateIgnoreNs, "replicate-ignore-namespaces", "", []string{""}, "namespaces that are ignored by replication")
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		if rootCmd.Flag("policy-label").Value.String() != "" || rootCmd.Flag("policy-value").Value.String() != "" {
@@ -205,7 +205,7 @@ func run(params *params) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	opts := data.WithIgnoreRelicas(params.replicateIgnoreNs)
+	opts := data.WithIgnoreNamespaces(params.replicateIgnoreNs)
 
 	for _, gvk := range params.replicateCluster {
 		sync := data.NewFromInterface(client, opa.New(params.opaURL, params.opaAuth).Prefix(params.replicatePath), getResourceType(gvk, false), opts)

--- a/pkg/data/generic.go
+++ b/pkg/data/generic.go
@@ -75,8 +75,8 @@ func NewFromInterface(client dynamic.Interface, opa opa_client.Data, ns types.Re
 	return s
 }
 
-// WithIgnoreRelicas provides a list of namespaces to ignore
-func WithIgnoreRelicas(ignoreNamespaces []string) Option {
+// WithIgnoreNamespaces provides a list of namespaces to ignore
+func WithIgnoreNamespaces(ignoreNamespaces []string) Option {
 	return func(s *GenericSync) {
 		s.ignoreNamespaces = ignoreNamespaces
 	}

--- a/pkg/data/generic_test.go
+++ b/pkg/data/generic_test.go
@@ -817,3 +817,46 @@ func mustAccess(t *testing.T, obj runtime.Object) metav1.Object {
 	}
 	return m
 }
+
+func TestGenericSync_ignoreNs(t *testing.T) {
+	type fields struct {
+		ignoreNamespaces []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "empty fields",
+			fields: fields{
+				[]string{},
+			},
+			want: "",
+		},
+		{
+			name: "one field",
+			fields: fields{
+				[]string{"cluster-autosscaler"},
+			},
+			want: "metadata.namespace!=cluster-autosscaler",
+		},
+		{
+			name: "two fields",
+			fields: fields{
+				[]string{"cluster-autoscaler", "cluster-manager"},
+			},
+			want: "metadata.namespace!=cluster-manager,metadata.namespace!=cluster-autoscaler",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &GenericSync{
+				ignoreNamespaces: tt.fields.ignoreNamespaces,
+			}
+			if got := s.ignoreNs(); got != tt.want {
+				t.Errorf("GenericSync.ignoreNs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/fixture-replication.yaml
+++ b/test/e2e/fixture-replication.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: dont-ignore-me
   namespace: dont-ignore-me
+  labels:
+    kube-mgmt/e2e: "true"
 apiVersion: v1
 data:
   values.yaml: |
@@ -29,4 +31,6 @@ metadata:
   annotations:
     control-plane.alpha.kubernetes.io/leader: '{"holderIdentity":"leader-election-dcf5bffb4-ggrhz","leaseDurationSeconds":60,"acquireTime":"2023-03-02T16:27:24Z","renewTime":"2023-03-04T02:10:06Z","leaderTransitions":211}'
   namespace: ignore-me
+  labels:
+    kube-mgmt/e2e: "true"
 apiVersion: v1

--- a/test/e2e/fixture-replication.yaml
+++ b/test/e2e/fixture-replication.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: ignore-me
+  name: ignore-me
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: dont-ignore-me
+  name: dont-ignore-me
+---
+kind: ConfigMap
+metadata:
+  name: dont-ignore-me
+  namespace: dont-ignore-me
+apiVersion: v1
+data:
+  values.yaml: |
+    app:
+      version: 12345
+---
+kind: ConfigMap
+metadata:
+  name: ignore-me-leader-election
+  annotations:
+    control-plane.alpha.kubernetes.io/leader: '{"holderIdentity":"leader-election-dcf5bffb4-ggrhz","leaseDurationSeconds":60,"acquireTime":"2023-03-02T16:27:24Z","renewTime":"2023-03-04T02:10:06Z","leaderTransitions":211}'
+  namespace: ignore-me
+apiVersion: v1

--- a/test/e2e/replication/test.sh
+++ b/test/e2e/replication/test.sh
@@ -7,6 +7,6 @@ OPA="http --ignore-stdin --default-scheme=https --verify=no -A bearer -a ${TOKEN
 kubectl apply -f "$(dirname $0)/../fixture-replication.yaml"
 
 # we are replicating all here so this should return data
-${OPA}/data/kubernetes/configmaps/ignore-me  | jq -e '.result|length>=0'
+${OPA}/data/kubernetes/configmaps/ignore-me  | jq -e '.result|length>=1'
 
-${OPA}/data/kubernetes/configmaps/dont-ignore-me  | jq -e '.result|length>=0'
+${OPA}/data/kubernetes/configmaps/dont-ignore-me  | jq -e '.result|length>=1'

--- a/test/e2e/replication/test.sh
+++ b/test/e2e/replication/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -ex
+
+TOKEN=$(kubectl exec deploy/kube-mgmt-opa-kube-mgmt -c mgmt -- cat /bootstrap/mgmt-token)
+OPA="http --ignore-stdin --default-scheme=https --verify=no -A bearer -a ${TOKEN} :8443/v1"
+
+kubectl apply -f "$(dirname $0)/../fixture-replication.yaml"
+
+# we are replicating all here so this should return data
+${OPA}/data/kubernetes/configmaps/ignore-me  | jq -e '.result|length>=0'
+
+${OPA}/data/kubernetes/configmaps/dont-ignore-me  | jq -e '.result|length>=0'

--- a/test/e2e/replication/test.sh
+++ b/test/e2e/replication/test.sh
@@ -6,7 +6,7 @@ OPA="http --ignore-stdin --default-scheme=https --verify=no -A bearer -a ${TOKEN
 
 kubectl apply -f "$(dirname $0)/../fixture-replication.yaml"
 
-# we are replicating all here so this should return data
-${OPA}/data/kubernetes/configmaps/ignore-me  | jq -e '.result|length>=1'
+# Due to a default configmap in each namespace you will find 2 `kube-root-ca.crt`
+${OPA}/data/kubernetes/configmaps/ignore-me  | jq -e '.result|length==2'
 
-${OPA}/data/kubernetes/configmaps/dont-ignore-me  | jq -e '.result|length>=1'
+${OPA}/data/kubernetes/configmaps/dont-ignore-me  | jq -e '.result|length==2'

--- a/test/e2e/replication/values.yaml
+++ b/test/e2e/replication/values.yaml
@@ -1,0 +1,4 @@
+mgmt:
+  extraArgs:
+    - "--log-level=debug"
+    - "--replicate=v1/configmaps"

--- a/test/e2e/replication/values.yaml
+++ b/test/e2e/replication/values.yaml
@@ -1,4 +1,10 @@
 mgmt:
-  extraArgs:
-    - "--log-level=debug"
-    - "--replicate=v1/configmaps"
+  replicate:
+    namespace:
+      - v1/configmaps
+rbac:
+  create: true
+  extraRules:
+    - apiGroups: [""]
+      resources: ["configmaps"]
+      verbs: ["*"]

--- a/test/e2e/replication_ignore_namespaces/test.sh
+++ b/test/e2e/replication_ignore_namespaces/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -ex
+
+TOKEN=$(kubectl exec deploy/kube-mgmt-opa-kube-mgmt -c mgmt -- cat /bootstrap/mgmt-token)
+OPA="http --ignore-stdin --default-scheme=https --verify=no -A bearer -a ${TOKEN} :8443/v1"
+
+kubectl apply -f "$(dirname $0)/../fixture-replication.yaml"
+
+${OPA}/data/kubernetes/configmaps/ignore-me  | jq -e '.result|length==0'
+
+${OPA}/data/kubernetes/configmaps/dont-ignore-me  | jq -e '.result|length>=0'

--- a/test/e2e/replication_ignore_namespaces/test.sh
+++ b/test/e2e/replication_ignore_namespaces/test.sh
@@ -8,4 +8,4 @@ kubectl apply -f "$(dirname $0)/../fixture-replication.yaml"
 
 ${OPA}/data/kubernetes/configmaps/ignore-me  | jq -e '.result|length==0'
 
-${OPA}/data/kubernetes/configmaps/dont-ignore-me  | jq -e '.result|length>=0'
+${OPA}/data/kubernetes/configmaps/dont-ignore-me  | jq -e '.result|length>=1'

--- a/test/e2e/replication_ignore_namespaces/test.sh
+++ b/test/e2e/replication_ignore_namespaces/test.sh
@@ -8,4 +8,4 @@ kubectl apply -f "$(dirname $0)/../fixture-replication.yaml"
 
 ${OPA}/data/kubernetes/configmaps/ignore-me  | jq -e '.result|length==0'
 
-${OPA}/data/kubernetes/configmaps/dont-ignore-me  | jq -e '.result|length>=1'
+${OPA}/data/kubernetes/configmaps/dont-ignore-me  | jq -e '.result|length==2'

--- a/test/e2e/replication_ignore_namespaces/values.yaml
+++ b/test/e2e/replication_ignore_namespaces/values.yaml
@@ -1,5 +1,12 @@
 mgmt:
   extraArgs:
-    - "--log-level=debug"
-    - "--replicate=v1/configmaps"
     - "--replicate-ignore-namespaces=ignore-me"
+  replicate:
+    namespace:
+      - v1/configmaps
+rbac:
+  create: true
+  extraRules:
+    - apiGroups: [""]
+      resources: ["configmaps"]
+      verbs: ["*"]

--- a/test/e2e/replication_ignore_namespaces/values.yaml
+++ b/test/e2e/replication_ignore_namespaces/values.yaml
@@ -1,0 +1,5 @@
+mgmt:
+  extraArgs:
+    - "--log-level=debug"
+    - "--replicate=v1/configmaps"
+    - "--replicate-ignore-namespaces=ignore-me"


### PR DESCRIPTION
We have a need to ignore namespaces.  This PR adds a way to do this with `--replicate-ignore-namespaces`, in another PR i would like to attempt to add `--replicate-ignore-annotations`, so that `control-plane.alpha.kubernetes.io/leader` could be added for those who choose to.  For this PR however the scope is limited just to ignore-namespaces as its easier to implement and users with a similar problem can leverage it to solve any immediate issues. 

What happens is when you load configmaps for whatever reason all the leader elections update every X seconds and then kube-mgmt then bombards OPA with reloads. This has the effect of driving load thru the roof, see screenshot below. This is a 5 second trace and the heap is going crazy!!!
![Screenshot 2023-02-21 at 4 18 53 PM](https://user-images.githubusercontent.com/16598119/220502642-5bc5d898-5a60-4ead-9005-cba5d42443e3.png)

Here is an example of a configmap with a leader election 
```
apiVersion: v1
kind: ConfigMap
metadata:
  annotations:
    control-plane.alpha.kubernetes.io/leader: '{"holderIdentity":"datadog-cluster-agent-dcf5bffb4-ggrhz","leaseDurationSeconds":60,"acquireTime":"2023-03-02T16:27:24Z","renewTime":"2023-03-04T02:10:06Z","leaderTransitions":211}'
  creationTimestamp: "2022-04-28T21:37:40Z"
  name: datadog-leader-election
  namespace: datadog
```

CPU before/after
<img width="1363" alt="Screenshot 2023-02-21 at 8 09 21 PM" src="https://user-images.githubusercontent.com/16598119/220503006-bd3fc0c9-30b0-4a62-8d7a-64cb46087deb.png">


