### PR TITLE
skip setting ignore namespace fieldSelector on cluster scoped resources.

### DIFF
--- a/pkg/data/generic.go
+++ b/pkg/data/generic.go
@@ -163,6 +163,9 @@ func (s *GenericSync) setup(ctx context.Context) (cache.Store, workqueue.Delayin
 
 func (s *GenericSync) ignoreNs() string {
 	var ignoreNs string
+	if !s.ns.Namespaced {
+		return ignoreNs
+	}
 	if len(s.ignoreNamespaces) >= 1 {
 		for _, ns := range s.ignoreNamespaces {
 			ignoreNs = FieldMeta + ns + "," + ignoreNs

--- a/pkg/data/generic_test.go
+++ b/pkg/data/generic_test.go
@@ -826,6 +826,7 @@ func TestGenericSync_ignoreNs(t *testing.T) {
 		name   string
 		fields fields
 		want   string
+		ns     types.ResourceType
 	}{
 		{
 			name: "empty fields",
@@ -833,6 +834,15 @@ func TestGenericSync_ignoreNs(t *testing.T) {
 				[]string{},
 			},
 			want: "",
+			ns:   types.ResourceType{Namespaced: true},
+		},
+		{
+			name: "one field",
+			fields: fields{
+				[]string{"cluster-autosscaler"},
+			},
+			want: "",
+			ns:   types.ResourceType{Namespaced: false},
 		},
 		{
 			name: "one field",
@@ -840,6 +850,7 @@ func TestGenericSync_ignoreNs(t *testing.T) {
 				[]string{"cluster-autosscaler"},
 			},
 			want: "metadata.namespace!=cluster-autosscaler",
+			ns:   types.ResourceType{Namespaced: true},
 		},
 		{
 			name: "two fields",
@@ -847,12 +858,14 @@ func TestGenericSync_ignoreNs(t *testing.T) {
 				[]string{"cluster-autoscaler", "cluster-manager"},
 			},
 			want: "metadata.namespace!=cluster-manager,metadata.namespace!=cluster-autoscaler",
+			ns:   types.ResourceType{Namespaced: true},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &GenericSync{
 				ignoreNamespaces: tt.fields.ignoreNamespaces,
+				ns:               tt.ns,
 			}
 			if got := s.ignoreNs(); got != tt.want {
 				t.Errorf("GenericSync.ignoreNs() = %v, want %v", got, tt.want)


### PR DESCRIPTION
fixes https://github.com/open-policy-agent/kube-mgmt/issues/195

prior to this patch, when a kube-mgmt is configured to replicate cluster scoped resources client-go fails with:

```
W0328 20:56:18.838009       1 reflector.go:324]
k8s.io/client-go@v0.23.8/tools/cache/reflector.go:167: failed to list
*unstructured.Unstructured: field label not supported:
metadata.namespace
E0328 20:56:18.838180       1 reflector.go:138]
k8s.io/client-go@v0.23.8/tools/cache/reflector.go:167: Failed to watch
*unstructured.Unstructured: failed to list *unstructured.Unstructured:
field label not supported: metadata.namespace
```

similar reproducer with `kubectl` is as below:

```
kubectl get ns --field-selector metadata.namespace!=foo

Error from server (BadRequest): Unable to find "/v1,
Resource=namespaces" that match label selector "", field selector
"metadata.namespace!=foo": field label not supported: metadata.namespace
```

This patch guards the setting of the fieldselector to only namespaced resources.