### PR TITLE
fix: helm chart serviceMonitor port definition

### DIFF
--- a/charts/opa-kube-mgmt/templates/servicemonitor.yaml
+++ b/charts/opa-kube-mgmt/templates/servicemonitor.yaml
@@ -18,7 +18,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - port: http
+  - port: diag
     interval: {{ .Values.serviceMonitor.interval }}
   jobLabel: {{ template "opa.fullname" . }}
   namespaceSelector:


### PR DESCRIPTION
Current `ServiceMonitor` template defines `http` as destination port for scraping metrics data, which is not set in the `Service` manifest, however `diag` is.

This commit updates the `ServiceMonitor` manifest to use `diag` port, which is exposed when prometheus is enabled.