### PR TITLE
Adding startup probe for kube-mgmt container

### DIFF
--- a/charts/opa-kube-mgmt/templates/deployment.yaml
+++ b/charts/opa-kube-mgmt/templates/deployment.yaml
@@ -170,6 +170,8 @@ spec:
         - name: mgmt
           image: {{ include "opa.mgmt.image" . }}
           imagePullPolicy: {{ .Values.mgmt.image.pullPolicy }}
+          startupProbe:
+{{ toYaml .Values.mgmt.startupProbe | nindent 12 }}
           env:
 {{- if .Values.mgmt.extraEnv }}
 {{ toYaml .Values.mgmt.extraEnv | indent 12 }}

--- a/charts/opa-kube-mgmt/values.yaml
+++ b/charts/opa-kube-mgmt/values.yaml
@@ -140,6 +140,20 @@ mgmt:
   extraEnv: []
   resources: {}
   namespaces: []
+
+  # kube-mgmt container will wait until OPA container comes to running state.
+  # Configure values for the startup probe, where kube-mgmt queries for the health 
+  # of OPA container before it starts.
+  startupProbe:
+    failureThreshold: 5
+    httpGet:
+      path: /health
+      port: 8181 # Port on which OPA is configured
+      scheme: HTTPS 
+    initialDelaySeconds: 20
+    successThreshold: 1
+    timeoutSeconds: 10
+
   data:
     enabled: true
   policies:

--- a/test/e2e/labels/values.yaml
+++ b/test/e2e/labels/values.yaml
@@ -6,6 +6,9 @@ authz:
   enabled: false
 
 mgmt:
+  startupProbe:
+    httpGet:
+      scheme: HTTP
   extraArgs:
     - "--policy-label=qweqwe/policy"
     - "--policy-value=111"

--- a/test/e2e/multi/values.yaml
+++ b/test/e2e/multi/values.yaml
@@ -6,5 +6,8 @@ authz:
   enabled: false
 
 mgmt:
+  startupProbe:
+    httpGet:
+      scheme: HTTP
   extraArgs:
     - "--log-level=debug"

--- a/test/e2e/no_https/values.yaml
+++ b/test/e2e/no_https/values.yaml
@@ -4,3 +4,8 @@ opa: null
 
 authz:
   enabled: false
+
+mgmt:
+  startupProbe:
+    httpGet:
+      scheme: HTTP


### PR DESCRIPTION
Fixes #210

Fix provided:

Before starting kube-mgmt container, the startup probe will check the health of OPA container using the API `<HTTP-SCHEME>://127.0.0.1:<OPA-PORT>/health` 

kubectl describe pod:
```
 Startup:        http-get https://:8181/health delay=20s timeout=1s period=10s #success=1 #failure=5
```
Pod came up successfully with the change
```
kc get pods
NAME                                 READY   STATUS    RESTARTS   AGE
opa-opa-kube-mgmt-66ff988f55-5wdjv   2/2     Running   0          32s
```
