### PR TITLE
Update the base image to Alpine 3.16.6

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,7 +6,7 @@ build:
   artifacts:
     - image: openpolicyagent/kube-mgmt
       ko:
-        fromImage: alpine:3.16.4
+        fromImage: alpine:3.16.6
         main: ./cmd/kube-mgmt/.../
         ldflags:
           - "-X github.com/open-policy-agent/kube-mgmt/pkg/version.Version={{.VERSION}}"


### PR DESCRIPTION
Adresses #191.

This PR updates the Alpine base image to 3.16.6, which is the latest version of Alpine 3.16. The image resolves the the two high vulnerabilities reported in the previous image.