### PR TITLE
Do not use ClusterRole and ClusterRoleBinding when .Values.mgmt.namespaces list is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ allow {
 * [Go language toolchain](https://go.dev/doc/install).
 * [just](https://github.com/casey/just#just) - generic command runner.
 * [skaffold](https://skaffold.dev/) - build and publish docker images and more, `v2.x` and above is required.
-* [helm](https://helm.sh/docs/intro/install/).
-* [k3d](https://k3d.io/v5.5.1/#installation) - local k8s cluster with docker registry.
+* [helm](https://helm.sh/docs/intro/install/)- package manager for k8s.
+* [k3d](https://k3d.io/#installation) - local k8s cluster with docker registry.
  
 This project uses `just` for buiding, testing and running `kube-mgmt` locally.
 It is configured from [justfile](./justfile) in root directory.
@@ -218,4 +218,4 @@ All available receipes can be inspected by running `just` without arguments.
 To release a new version - create [GitHub release](https://github.com/open-policy-agent/kube-mgmt/releases)
 with corresponding tag name that follows [semantic versioning convention](https://semver.org/).
 
-As soon as tag is pushed - CI pipeline will build and publish all the artifacts.
+As soon as tag is pushed - CI pipeline will build and publish artifacts: docker images for supported architectures and helm chart.

--- a/README.md
+++ b/README.md
@@ -199,15 +199,23 @@ allow {
 }
 ```
 
-## Development Guide
+## Development
 
-This project uses excellent tool [Just](https://github.com/casey/just#just) for buiding.
-It is configured by [justfile](./justfile) file in root directory.
-All available targets can be inspected by running `just` in command line.
+### Required software
 
-## Release procedure
+* [Go language toolchain](https://go.dev/doc/install).
+* [just](https://github.com/casey/just#just) - generic command runner.
+* [skaffold](https://skaffold.dev/) - build and publish docker images and more, `v2.x` and above is required.
+* [helm](https://helm.sh/docs/intro/install/).
+* [k3d](https://k3d.io/v5.5.1/#installation) - local k8s cluster with docker registry.
+ 
+This project uses `just` for buiding, testing and running `kube-mgmt` locally.
+It is configured from [justfile](./justfile) in root directory.
+All available receipes can be inspected by running `just` without arguments.
 
-To release a new version - just create [GitHub release](https://github.com/open-policy-agent/kube-mgmt/releases)
-with corresponding tag, following semantic version converntion.
+### Release
 
-As soon as tag will be pushed - CI pipeline will build and publish all artifacts.
+To release a new version - create [GitHub release](https://github.com/open-policy-agent/kube-mgmt/releases)
+with corresponding tag name that follows [semantic versioning convention](https://semver.org/).
+
+As soon as tag is pushed - CI pipeline will build and publish all the artifacts.

--- a/charts/opa-kube-mgmt/templates/deployment.yaml
+++ b/charts/opa-kube-mgmt/templates/deployment.yaml
@@ -181,7 +181,11 @@ spec:
             {{- end }}
             - --opa-url={{ .Values.useHttps | ternary "https" "http" }}://127.0.0.1:{{ .Values.port }}/v1
             - --opa-allow-insecure
+            {{- if has "*" .Values.mgmt.namespaces }}
+            - --namespaces=*
+            {{- else }}
             - --namespaces={{ coalesce .Values.mgmt.namespaces (list .Release.Namespace) | join "," }}
+            {{- end }}
             - --enable-data={{ .Values.mgmt.data.enabled }}
             - --enable-policies={{ .Values.mgmt.policies.enabled }}
             - --replicate-path={{ .Values.mgmt.replicate.path }}

--- a/charts/opa-kube-mgmt/templates/rbac-mgmt.yaml
+++ b/charts/opa-kube-mgmt/templates/rbac-mgmt.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.rbac.create }}
+
+{{- if has "*" .Values.mgmt.namespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -27,6 +29,7 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch"]
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -46,4 +49,56 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "opa.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+
+{{- else }}
+{{- range (coalesce .Values.mgmt.namespaces (list .Release.Namespace)) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "opa.name" $ }}
+    chart: {{ template "opa.chart" $ }}
+    heritage: {{ $.Release.Service }}
+    release: {{ $.Release.Name }}
+    component: mgmt
+  name: {{ template "opa.mgmtfullname" $ }}
+  namespace: {{ . }}
+rules:
+  # Inject user-provided RBAC rules
+  {{- with $.Values.rbac.extraRules }}
+  {{ . | toYaml | nindent 2 }}
+  {{- end }}
+
+  # Allow kube-mgmt to have "get", "list" and "watch" actions over ConfigMaps at a cluster level
+  # to allow loading policies from any namespace.
+  # Additionally, allow "patch" and "update" actionson ConfigMaps so kube-mgmt can
+  # annotate the ConfigMaps to indicate if they were loaded successfully or not.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "opa.name" $ }}
+    chart: {{ template "opa.chart" $ }}
+    heritage: {{ $.Release.Service }}
+    release: {{ $.Release.Name }}
+    component: mgmt
+  name: {{ template "opa.mgmtfullname" $ }}
+  namespace: {{ . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "opa.mgmtfullname" $ }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "opa.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}
+
 {{- end }}

--- a/test/e2e/replication/values.yaml
+++ b/test/e2e/replication/values.yaml
@@ -1,5 +1,5 @@
 mgmt:
-  namespaces: ["ignore-me", "dont-ignore-me"]
+  namespaces: ["*"]
   replicate:
     namespace:
       - v1/configmaps

--- a/test/e2e/replication/values.yaml
+++ b/test/e2e/replication/values.yaml
@@ -1,4 +1,5 @@
 mgmt:
+  namespaces: ["ignore-me", "dont-ignore-me"]
   replicate:
     namespace:
       - v1/configmaps

--- a/test/e2e/replication_ignore_namespaces/values.yaml
+++ b/test/e2e/replication_ignore_namespaces/values.yaml
@@ -1,4 +1,5 @@
 mgmt:
+  namespaces: ["ignore-me", "dont-ignore-me"]
   extraArgs:
     - "--replicate-ignore-namespaces=ignore-me"
   replicate:

--- a/test/e2e/replication_ignore_namespaces/values.yaml
+++ b/test/e2e/replication_ignore_namespaces/values.yaml
@@ -1,5 +1,5 @@
 mgmt:
-  namespaces: ["ignore-me", "dont-ignore-me"]
+  namespaces: ["*"]
   extraArgs:
     - "--replicate-ignore-namespaces=ignore-me"
   replicate:


### PR DESCRIPTION
Support watching all namespaces (*) or only one with limited privileges (no ClusterRole and ClusterRoleBinding).

Default values are backward compatible.

Closes https://github.com/open-policy-agent/kube-mgmt/issues/212.