### PR TITLE
Update the base image Alpine to 3.16.7

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,7 +6,7 @@ build:
   artifacts:
     - image: openpolicyagent/kube-mgmt
       ko:
-        fromImage: alpine:3.16.6
+        fromImage: alpine:3.16.7
         main: ./cmd/kube-mgmt/.../
         ldflags:
           - "-X github.com/open-policy-agent/kube-mgmt/pkg/version.Version={{.VERSION}}"


### PR DESCRIPTION
Pulling in fixes for some OS CVEs
[CVE-2023-2975](https://security.alpinelinux.org/vuln/CVE-2023-2975)
[CVE-2023-3446](https://security.alpinelinux.org/vuln/CVE-2023-3446)
[CVE-2023-3817](https://security.alpinelinux.org/vuln/CVE-2023-3817)