### PR TITLE
Add template for ServiceAccount annotations

### DIFF
--- a/charts/opa-kube-mgmt/templates/serviceaccount.yaml
+++ b/charts/opa-kube-mgmt/templates/serviceaccount.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "opa.serviceAccountName" .}}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{ toYaml . }}
+  {{- end }}
   labels:
     app: {{ template "opa.fullname" . }}
     chart: {{ template "opa.chart" . }}

--- a/charts/opa-kube-mgmt/values.schema.json
+++ b/charts/opa-kube-mgmt/values.schema.json
@@ -23,6 +23,14 @@
         "enabled": {"type": "boolean", "default": true},
         "image": {"$ref": "#/definitions/image"}
       }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {"type": "boolean", "default": true},
+        "annotations": {"type": "object", "additionalProperties": {"type": "string"}, "default": {}},
+        "name": {"type": ["string", "null"], "default": null}
+      }
     }
   }
 }

--- a/charts/opa-kube-mgmt/values.yaml
+++ b/charts/opa-kube-mgmt/values.yaml
@@ -223,6 +223,8 @@ rbac:
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
+  # Annotations for the ServiceAccount
+  annotations: {}
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:

--- a/test/lint/sa.yaml
+++ b/test/lint/sa.yaml
@@ -1,0 +1,15 @@
+suite: lint serviceaccount
+templates:
+  - fake.yaml
+tests:
+  - it: annotations not string
+    set:
+      serviceAccount:
+        annotations:
+          foo: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: |
+            values don't meet the specifications of the schema(s) in the following chart(s):
+            opa-kube-mgmt:
+            - serviceAccount.annotations.foo: Invalid type. Expected: string, given: integer

--- a/test/unit/sa_test.yaml
+++ b/test/unit/sa_test.yaml
@@ -1,0 +1,19 @@
+suite: test serviceaccount annotations
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should omit serviceaccount annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+  - it: should render serviceaccount annotations when provided
+    set:
+      serviceAccount:
+        annotations:
+          foo: bar
+    asserts:
+      - exists:
+          path: metadata.annotations
+      - equal:
+          path: metadata.annotations.foo
+          value: bar


### PR DESCRIPTION
ServiceAccount annotations are needed to support web identity credentials: https://www.openpolicyagent.org/docs/latest/management-bundles/#web-identity-credentials