### PR TITLE
Update alpine image to 3.19.1 to fix CVE for base image- CVE-2023-5678

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,7 +6,7 @@ build:
   artifacts:
     - image: openpolicyagent/kube-mgmt
       ko:
-        fromImage: alpine:3.16.7
+        fromImage: alpine:3.19.1
         main: ./cmd/kube-mgmt/.../
         ldflags:
           - "-X github.com/open-policy-agent/kube-mgmt/pkg/version.Version={{.VERSION}}"


### PR DESCRIPTION
Upgrade of base alpine image to latest.
Ran trivy scan on base image and no vulnerabilities encouuntered.
Before fix:

![image](https://github.com/open-policy-agent/kube-mgmt/assets/25053539/ec287aaa-b8ae-462b-bb0f-35cf0da437c8)


After upgrade of alpine image:
![image](https://github.com/open-policy-agent/kube-mgmt/assets/25053539/193a6786-6c6c-4f2a-aa40-13b56d7c23a4)

Closes #247 