### PR TITLE
Update  base alpine image to 3.20.2

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,7 +6,7 @@ build:
   artifacts:
     - image: openpolicyagent/kube-mgmt
       ko:
-        fromImage: alpine:3.19.1
+        fromImage: alpine:3.20.2
         main: ./cmd/kube-mgmt/.../
         ldflags:
           - "-X github.com/open-policy-agent/kube-mgmt/pkg/version.Version={{.VERSION}}"


### PR DESCRIPTION
Update base alpine image to 3.20.2 to get fixes for CVEs.

Signed-off-by: porwalameet <porwalameet@gmail.com>