### PR TITLE
Add webhookconfig checksum to deployment annotations

### DIFF
--- a/charts/opa-kube-mgmt/templates/deployment.yaml
+++ b/charts/opa-kube-mgmt/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         {{- if .Values.opa }}
         checksum/config: {{ tpl (toYaml .Values.opa) . | sha256sum }}
         {{- end }}
+        {{- if .Values.admissionController.enabled }}
+        checksum/webhookconfiguration: {{ include (print $.Template.BasePath "/webhookconfiguration.yaml" ) . | sha256sum }}
+        {{- end }}
 {{- if .Values.annotations }}
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}


### PR DESCRIPTION
Changing the webhook sometimes results into the creation of a new certificate and because of that an updated secret.
The updated secret introduces the following error:

`tls: failed to verify certificate: x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "opa-admission-ca")`

The secret is updated in the pod (since kubernetes automatically updates mounted secrets and configmaps), but the OPA process does not reload the secrets. After restarting the pods the issue is solved, we now how to do this manually for each update to this chart.

Adding the sha256 of the certificate secret as an annotation will result in an update to the deployment and thus restarting its pods.