### PR TITLE
feat: add Service annotations

### DIFF
--- a/charts/opa-kube-mgmt/templates/service.yaml
+++ b/charts/opa-kube-mgmt/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ template "opa.fullname" . }}
   labels:
 {{ include "opa.labels.standard" . | indent 4 }}
+{{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   selector:
     app: {{ template "opa.fullname" . }}
@@ -18,4 +22,7 @@ spec:
 {{- end }}
 {{- if .Values.extraPorts }}
 {{ toYaml .Values.extraPorts | indent 2}}
+{{- end }}
+{{- if .Values.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.service.trafficDistribution }}
 {{- end }}

--- a/charts/opa-kube-mgmt/values.schema.json
+++ b/charts/opa-kube-mgmt/values.schema.json
@@ -31,6 +31,21 @@
         "annotations": {"type": "object", "additionalProperties": {"type": "string"}, "default": {}},
         "name": {"type": ["string", "null"], "default": null}
       }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {"type": "string"},
+          "default": {}
+        },
+        "trafficDistribution": {
+          "type": ["null","string"],
+          "enum": ["PreferZone", "PreferSameNode", "PreferSameZone", null],
+          "default": null
+        }
+      }
     }
   }
 }

--- a/charts/opa-kube-mgmt/values.yaml
+++ b/charts/opa-kube-mgmt/values.yaml
@@ -26,6 +26,13 @@ serviceMonitor:
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
   additionalLabels: {}
 
+# Service configuration
+service:
+  # Annotations to add to the service
+  annotations: {}
+  # Configure trafficDistribution if needed.
+  # trafficDistribution: PreferSameZone
+
 # Annotations in the deployment template
 annotations: {}
 
@@ -293,4 +300,3 @@ extraPorts: []
 #   protocol: TCP
 #   name: http
 #   targetPort: http
-

--- a/test/e2e/custom_config/values.yaml
+++ b/test/e2e/custom_config/values.yaml
@@ -5,5 +5,5 @@ opa:
   bundles:
     quickstart:
       service: controller
-      resource: /bundles/helm-kubernetes-quickstart
+      resource: /external-resources/bundles/helm-kubernetes-quickstart
   default_decision: /helm_kubernetes_quickstart/main

--- a/test/lint/service.yaml
+++ b/test/lint/service.yaml
@@ -1,0 +1,25 @@
+suite: lint service
+templates:
+  - service.yaml
+tests:
+  - it: service annotations must be a string for foo
+    set:
+      service:
+        annotations:
+          bar: true
+          baz: ["invalid"]
+          foo:
+            bar: baz
+    asserts:
+      - failedTemplate:
+          errorPattern: "Invalid type. Expected: string, given"
+  - it: trafficDistribution invalid value
+    set:
+      service:
+        trafficDistribution: "InvalidValue"
+    asserts:
+      - failedTemplate:
+          errorMessage: |
+            values don't meet the specifications of the schema(s) in the following chart(s):
+            opa-kube-mgmt:
+            - service.trafficDistribution: service.trafficDistribution must be one of the following: "PreferZone", "PreferSameNode", "PreferSameZone", null

--- a/test/unit/service.yaml
+++ b/test/unit/service.yaml
@@ -1,0 +1,30 @@
+suite: test service definition
+templates:
+  - service.yaml
+tests:
+  - it: should omit service annotations when null
+    set:
+      service.annotations: null
+    asserts:
+      - notExists:
+          path: metadata.annotations.foo
+  - it: should set service annotations
+    set:
+      service.annotations:
+        foo: bar
+    asserts:
+      - exists:
+          path: metadata.annotations.foo
+      - equal:
+          path: metadata.annotations.foo
+          value: bar
+  - it: should omit trafficDistribution by default
+    asserts:
+      - notExists:
+          path: spec.trafficDistribution
+  - it: should omit trafficDistribution when null
+    set:
+      service.trafficDistribution: null
+    asserts:
+      - notExists:
+          path: spec.trafficDistribution


### PR DESCRIPTION
- adding helm chart functionality to specify Service annotations and `trafficDistribution` configuration to allow users to configure shortest path to the pods