### PR TITLE
fix: update trafficDistribution possible values

### DIFF
--- a/charts/opa-kube-mgmt/values.schema.json
+++ b/charts/opa-kube-mgmt/values.schema.json
@@ -42,7 +42,7 @@
         },
         "trafficDistribution": {
           "type": ["null","string"],
-          "enum": ["PreferZone", "PreferSameNode", "PreferSameZone", null],
+          "enum": ["PreferClose", "PreferSameNode", "PreferSameZone", null],
           "default": null
         }
       }

--- a/test/lint/service.yaml
+++ b/test/lint/service.yaml
@@ -22,4 +22,4 @@ tests:
           errorMessage: |
             values don't meet the specifications of the schema(s) in the following chart(s):
             opa-kube-mgmt:
-            - service.trafficDistribution: service.trafficDistribution must be one of the following: "PreferZone", "PreferSameNode", "PreferSameZone", null
+            - service.trafficDistribution: service.trafficDistribution must be one of the following: "PreferClose", "PreferSameNode", "PreferSameZone", null


### PR DESCRIPTION
- update tests for opa-kube-mgmt helm chart to reflect the possible values for `trafficDistribution`