### PR TITLE
fix: bump alpine to latest

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,7 +6,7 @@ build:
   artifacts:
     - image: openpolicyagent/kube-mgmt
       ko:
-        fromImage: alpine:3.20.2
+        fromImage: alpine:3.20.8
         main: ./cmd/kube-mgmt/.../
         ldflags:
           - "-X github.com/open-policy-agent/kube-mgmt/pkg/version.Version={{.VERSION}}"


### PR DESCRIPTION
Fixes Snyk High severity vulerability found in openssl/libcrypto3
https://security.snyk.io/vuln/SNYK-ALPINE320-OPENSSL-7895537