### PR TITLE
feat: support topologySpreadConstraints in helm chart

### DIFF
--- a/charts/opa-kube-mgmt/templates/deployment.yaml
+++ b/charts/opa-kube-mgmt/templates/deployment.yaml
@@ -292,3 +292,5 @@ spec:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
+      topologySpreadConstraints:
+{{ toYaml .Values.topologySpreadConstraints | indent 8 }}

--- a/charts/opa-kube-mgmt/values.schema.json
+++ b/charts/opa-kube-mgmt/values.schema.json
@@ -46,6 +46,65 @@
           "default": null
         }
       }
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["maxSkew", "topologyKey", "whenUnsatisfiable"],
+        "properties": {
+          "maxSkew": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "topologyKey": {
+            "type": "string",
+            "minLength": 1
+          },
+          "whenUnsatisfiable": {
+            "type": "string",
+            "enum": ["DoNotSchedule", "ScheduleAnyway"]
+          },
+          "labelSelector": {
+            "type": "object",
+            "properties": {
+              "matchLabels": {
+                "type": "object",
+                "additionalProperties": {"type": "string"}
+              },
+              "matchExpressions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["key", "operator"],
+                  "properties": {
+                    "key": {"type": "string"},
+                    "operator": {"type": "string", "enum": ["In", "NotIn", "Exists", "DoesNotExist"]},
+                    "values": {"type": "array", "items": {"type": "string"}}
+                  }
+                }
+              }
+            }
+          },
+          "matchLabelKeys": {
+            "type": "array",
+            "items": {"type": "string"}
+          },
+          "minDomains": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "nodeAffinityPolicy": {
+            "type": "string",
+            "enum": ["Honor", "Ignore"]
+          },
+          "nodeTaintsPolicy": {
+            "type": "string",
+            "enum": ["Honor", "Ignore"]
+          }
+        }
+      },
+      "default": []
     }
   }
 }

--- a/charts/opa-kube-mgmt/values.yaml
+++ b/charts/opa-kube-mgmt/values.yaml
@@ -219,6 +219,18 @@ affinity: {}
 tolerations: []
 nodeSelector: {}
 
+# To control pod distribution across topology domains, set topologySpreadConstraints
+# below.
+#
+# topologySpreadConstraints:
+# - maxSkew: 1
+#   topologyKey: topology.kubernetes.io/zone
+#   whenUnsatisfiable: DoNotSchedule
+#   labelSelector:
+#     matchLabels:
+#       app: opa
+topologySpreadConstraints: []
+
 # To control the CPU and memory resource limits and requests for OPA, set the
 # field below.
 resources: {}

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ _latest:
   fi
 
 _helm-unittest:
-  helm plugin ls | grep unittest || helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.8.2
+  helm plugin ls | grep unittest || helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3
 
 # golang linter
 lint-go:

--- a/test/lint/images.yaml
+++ b/test/lint/images.yaml
@@ -10,7 +10,8 @@ tests:
           errorMessage: |
             values don't meet the specifications of the schema(s) in the following chart(s):
             opa-kube-mgmt:
-            - (root): image is required
+            - at '': missing property 'image'
+
   - it: image.repository not string
     set:
       image:
@@ -20,7 +21,8 @@ tests:
           errorMessage: |
             values don't meet the specifications of the schema(s) in the following chart(s):
             opa-kube-mgmt:
-            - image.repository: Invalid type. Expected: string, given: integer
+            - at '/image/repository': got number, want string
+
   - it: image.tag not string
     set:
       image:
@@ -30,7 +32,8 @@ tests:
           errorMessage: |
             values don't meet the specifications of the schema(s) in the following chart(s):
             opa-kube-mgmt:
-            - image.tag: Invalid type. Expected: string, given: integer
+            - at '/image/tag': got number, want string
+
   - it: mgmt.image is null
     set:
       mgmt:
@@ -40,7 +43,8 @@ tests:
           errorMessage: |
             values don't meet the specifications of the schema(s) in the following chart(s):
             opa-kube-mgmt:
-            - mgmt: image is required
+            - at '/mgmt': missing property 'image'
+
   - it: mgmt.image.repository not string
     set:
       mgmt:
@@ -51,7 +55,8 @@ tests:
           errorMessage: |
             values don't meet the specifications of the schema(s) in the following chart(s):
             opa-kube-mgmt:
-            - mgmt.image.repository: Invalid type. Expected: string, given: integer
+            - at '/mgmt/image/repository': got number, want string
+
   - it: mgmt.image.tag not string
     set:
       mgmt:
@@ -62,4 +67,4 @@ tests:
           errorMessage: |
             values don't meet the specifications of the schema(s) in the following chart(s):
             opa-kube-mgmt:
-            - mgmt.image.tag: Invalid type. Expected: string, given: integer
+            - at '/mgmt/image/tag': got number, want string

--- a/test/lint/sa.yaml
+++ b/test/lint/sa.yaml
@@ -9,7 +9,4 @@ tests:
           foo: 1
     asserts:
       - failedTemplate:
-          errorMessage: |
-            values don't meet the specifications of the schema(s) in the following chart(s):
-            opa-kube-mgmt:
-            - serviceAccount.annotations.foo: Invalid type. Expected: string, given: integer
+          errorPattern: "got number, want string"

--- a/test/lint/service.yaml
+++ b/test/lint/service.yaml
@@ -2,17 +2,34 @@ suite: lint service
 templates:
   - service.yaml
 tests:
-  - it: service annotations must be a string for foo
+  - it: fails when service annotation is boolean
     set:
       service:
         annotations:
           bar: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "got boolean, want string"
+
+  - it: fails when service annotation is array
+    set:
+      service:
+        annotations:
           baz: ["invalid"]
+    asserts:
+      - failedTemplate:
+          errorPattern: "got array, want string"
+
+  - it: fails when service annotation is object
+    set:
+      service:
+        annotations:
           foo:
             bar: baz
     asserts:
       - failedTemplate:
-          errorPattern: "Invalid type. Expected: string, given"
+          errorPattern: "got object, want string"
+
   - it: trafficDistribution invalid value
     set:
       service:
@@ -22,4 +39,4 @@ tests:
           errorMessage: |
             values don't meet the specifications of the schema(s) in the following chart(s):
             opa-kube-mgmt:
-            - service.trafficDistribution: service.trafficDistribution must be one of the following: "PreferClose", "PreferSameNode", "PreferSameZone", null
+            - at '/service/trafficDistribution': value must be one of 'PreferClose', 'PreferSameNode', 'PreferSameZone', <nil>

--- a/test/lint/tsc.yaml
+++ b/test/lint/tsc.yaml
@@ -1,0 +1,79 @@
+suite: lint topologySpreadConstraints
+templates:
+  - deployment.yaml
+tests:
+  - it: fails when maxSkew is missing
+    set:
+      topologySpreadConstraints:
+        - topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: "DoNotSchedule"
+    asserts:
+      - failedTemplate: {}
+
+  - it: fails when maxSkew is null
+    set:
+      topologySpreadConstraints:
+        - maxSkew: null
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: "DoNotSchedule"
+    asserts:
+      - failedTemplate: {}
+
+  - it: fails when topologyKey is missing
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          whenUnsatisfiable: "DoNotSchedule"
+    asserts:
+      - failedTemplate: {}
+
+  - it: fails when whenUnsatisfiable is missing
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+    asserts:
+      - failedTemplate: {}
+
+  - it: fails when maxSkew is not an integer
+    set:
+      topologySpreadConstraints:
+        - maxSkew: "one"
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: "DoNotSchedule"
+    asserts:
+      - failedTemplate: {}
+
+  - it: fails when topologyKey is empty string
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: ""
+          whenUnsatisfiable: "DoNotSchedule"
+    asserts:
+      - failedTemplate: {}
+
+  - it: fails when whenUnsatisfiable has invalid value
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: "InvalidOption"
+    asserts:
+      - failedTemplate: {}
+
+  - it: renders with empty topologySpreadConstraints array
+    set:
+      topologySpreadConstraints: []
+    asserts:
+      - isKind:
+          of: Deployment
+      - isEmpty:
+          path: spec.template.spec.topologySpreadConstraints
+
+  - it: renders without topologySpreadConstraints when not set
+    asserts:
+      - isKind:
+          of: Deployment
+      - isEmpty:
+          path: spec.template.spec.topologySpreadConstraints

--- a/test/unit/tsc.yaml
+++ b/test/unit/tsc.yaml
@@ -1,0 +1,173 @@
+suite: test topologySpreadConstraints
+templates:
+  - deployment.yaml
+tests:
+  - it: renders with DoNotSchedule policy
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: "DoNotSchedule"
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.topologySpreadConstraints
+          content:
+            maxSkew: 1
+            topologyKey: "kubernetes.io/hostname"
+            whenUnsatisfiable: "DoNotSchedule"
+
+  - it: renders multiple topologySpreadConstraints
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "traffic.kubernetes.io/region"
+          whenUnsatisfiable: "ScheduleAnyway"
+        - maxSkew: 2
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: "DoNotSchedule"
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.topologySpreadConstraints
+          count: 2
+      - contains:
+          path: spec.template.spec.topologySpreadConstraints
+          content:
+            topologyKey: "traffic.kubernetes.io/region"
+          any: true
+      - contains:
+          path: spec.template.spec.topologySpreadConstraints
+          content:
+            topologyKey: "topology.kubernetes.io/zone"
+          any: true
+
+  - it: renders with labelSelector
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: "DoNotSchedule"
+          labelSelector:
+            matchLabels:
+              app: opa-kube-mgmt
+    asserts:
+      - contains:
+          path: spec.template.spec.topologySpreadConstraints
+          content:
+            maxSkew: 1
+            topologyKey: "kubernetes.io/hostname"
+            whenUnsatisfiable: "DoNotSchedule"
+            labelSelector:
+              matchLabels:
+                app: opa-kube-mgmt
+
+  - it: renders with minDomains
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: "DoNotSchedule"
+          minDomains: 3
+    asserts:
+      - contains:
+          path: spec.template.spec.topologySpreadConstraints
+          content:
+            minDomains: 3
+          any: true
+
+  - it: passes through constraint with labelSelector
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: "DoNotSchedule"
+          labelSelector:
+            matchLabels:
+              app: opa-kube-mgmt
+            matchExpressions:
+              - key: environment
+                operator: In
+                values:
+                  - production
+                  - staging
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector
+          value:
+            matchLabels:
+              app: opa-kube-mgmt
+            matchExpressions:
+              - key: environment
+                operator: In
+                values:
+                  - production
+                  - staging
+
+  - it: passes through constraint with nodeAffinityPolicy
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: "DoNotSchedule"
+          nodeAffinityPolicy: "Honor"
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].nodeAffinityPolicy
+          value: "Honor"
+
+  - it: passes through constraint with nodeTaintsPolicy
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: "DoNotSchedule"
+          nodeTaintsPolicy: "Ignore"
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].nodeTaintsPolicy
+          value: "Ignore"
+
+  - it: passes through constraint with matchLabelKeys
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: "DoNotSchedule"
+          matchLabelKeys:
+            - config
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].matchLabelKeys
+          value:
+            - config
+
+  - it: passes through fully configured constraint
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 2
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: "ScheduleAnyway"
+          minDomains: 3
+          nodeAffinityPolicy: "Honor"
+          nodeTaintsPolicy: "Honor"
+          matchLabelKeys:
+            - pod-template-hash
+          labelSelector:
+            matchLabels:
+              app: opa-kube-mgmt
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0]
+          value:
+            maxSkew: 2
+            topologyKey: "topology.kubernetes.io/zone"
+            whenUnsatisfiable: "ScheduleAnyway"
+            minDomains: 3
+            nodeAffinityPolicy: "Honor"
+            nodeTaintsPolicy: "Honor"
+            matchLabelKeys:
+              - pod-template-hash
+            labelSelector:
+              matchLabels:
+                app: opa-kube-mgmt


### PR DESCRIPTION
- adding support for topologySpreadConstraints to allow configuring different topology strategies in OPA deployments