### PR TITLE
fix: Bump alpine base image to 3.23.5

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: alpine:3.23.4
+defaultBaseImage: alpine:3.23.5
 builds:
   - id: kube-mgmt
     main: ./cmd/kube-mgmt


### PR DESCRIPTION
- Primarily to fix CVE-2026-34182

[CVE-2026-34182](https://github.com/advisories/GHSA-f9v2-4w9p-2cwc) is fixed in libcrypto3/libssl3, which is included in alpine:3.23.5.

cc @eshepelyuk - if you merge this can you also create a new release for it? Thanks! 🙇 